### PR TITLE
Fix manifest data specifier

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include src/disp_s1/data *.json.zip
+recursive-include src/disp_s1/data *.json.zip


### PR DESCRIPTION
`include` matches files relative to the project, so this include pattern did nothing
We need to use `recursive-include` to match files with a specific file extension under a given directory

See https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html#controlling-files-in-the-distribution