### PR TITLE
Replace unwrapped phase layer with displacement in DISP-S1 product

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
 
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.8
+    rev: v0.4.9
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --show-fixes]

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -129,6 +129,7 @@ def create_output_product(
 
     wavelength, _ = _parse_cslc_product.get_radar_wavelength(cslc_files[-1])
     phase2range = -1 * float(wavelength) / (4.0 * np.pi)
+    range_change_arr = unw_arr * phase2range
 
     with h5netcdf.File(output_name, "w", **FILE_OPTS) as f:
         # Create the NetCDF file
@@ -138,7 +139,9 @@ def create_output_product(
         _create_grid_mapping(group=f, crs=crs, gt=gt)
 
         # Set up the X/Y variables for each group
-        _create_yx_dsets(group=f, gt=gt, shape=unw_arr.shape, include_time=True)
+        _create_yx_dsets(
+            group=f, gt=gt, shape=range_change_arr.shape, include_time=True
+        )
         _create_time_dset(
             group=f,
             time=start_time,
@@ -149,7 +152,7 @@ def create_output_product(
         # Write the displacement array / conncomp arrays
         disp_products_info = DISP_PRODUCTS_INFO
         disp_data = [
-            unw_arr * phase2range,
+            range_change_arr,
             conncomp_arr,
             temp_coh_arr,
             ifg_corr_arr,

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -127,6 +127,9 @@ def create_output_product(
     ]
     end_time = max(end_times)
 
+    wavelength, _ = _parse_cslc_product.get_radar_wavelength(cslc_files[-1])
+    phase2range = -1 * float(wavelength) / (4.0 * np.pi)
+
     with h5netcdf.File(output_name, "w", **FILE_OPTS) as f:
         # Create the NetCDF file
         f.attrs.update(GLOBAL_ATTRS)
@@ -146,7 +149,7 @@ def create_output_product(
         # Write the displacement array / conncomp arrays
         disp_products_info = DISP_PRODUCTS_INFO
         disp_data = [
-            unw_arr,
+            unw_arr * phase2range,
             conncomp_arr,
             temp_coh_arr,
             ifg_corr_arr,

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -128,8 +128,8 @@ def create_output_product(
     end_time = max(end_times)
 
     wavelength, _ = _parse_cslc_product.get_radar_wavelength(cslc_files[-1])
-    phase2range = -1 * float(wavelength) / (4.0 * np.pi)
-    range_change_arr = unw_arr * phase2range
+    phase2disp = -1 * float(wavelength) / (4.0 * np.pi)
+    disp_arr = unw_arr * phase2disp
 
     with h5netcdf.File(output_name, "w", **FILE_OPTS) as f:
         # Create the NetCDF file
@@ -139,9 +139,7 @@ def create_output_product(
         _create_grid_mapping(group=f, crs=crs, gt=gt)
 
         # Set up the X/Y variables for each group
-        _create_yx_dsets(
-            group=f, gt=gt, shape=range_change_arr.shape, include_time=True
-        )
+        _create_yx_dsets(group=f, gt=gt, shape=disp_arr.shape, include_time=True)
         _create_time_dset(
             group=f,
             time=start_time,
@@ -152,7 +150,7 @@ def create_output_product(
         # Write the displacement array / conncomp arrays
         disp_products_info = DISP_PRODUCTS_INFO
         disp_data = [
-            range_change_arr,
+            disp_arr,
             conncomp_arr,
             temp_coh_arr,
             ifg_corr_arr,
@@ -175,7 +173,7 @@ def create_output_product(
     _create_corrections_group(
         output_name=output_name,
         corrections=corrections,
-        shape=unw_arr.shape,
+        shape=disp_arr.shape,
         gt=gt,
         crs=crs,
         start_time=min(start_times),

--- a/src/disp_s1/product_info.py
+++ b/src/disp_s1/product_info.py
@@ -19,11 +19,14 @@ class DispProductInfo:
     attrs: dict
 
     @classmethod
-    def range_change(cls):
+    def displacement(cls):
         """Return container of range change specific information."""
         return cls(
-            name="range_change",
-            description="Range change",
+            name="displacement",
+            description=(
+                "Displacement (w/noise) in LOS. "
+                "Positive values indicate apparent motion towards the platform."
+            ),
             fillvalue=np.nan,
             attrs={"units": "meters"},
         )
@@ -79,7 +82,7 @@ class DispProductInfo:
 class DispProductsInfo:
     """Container for instantiated displacement product dataset info containers."""
 
-    range_change: DispProductInfo = DispProductInfo.range_change()
+    displacement: DispProductInfo = DispProductInfo.displacement()
     connected_component_labels: DispProductInfo = (
         DispProductInfo.connected_component_labels()
     )

--- a/src/disp_s1/product_info.py
+++ b/src/disp_s1/product_info.py
@@ -19,13 +19,13 @@ class DispProductInfo:
     attrs: dict
 
     @classmethod
-    def unwrapped_phase(cls):
-        """Return container of unwrapped phase specific information."""
+    def range_change(cls):
+        """Return container of range change specific information."""
         return cls(
-            name="unwrapped_phase",
-            description="Unwrapped phase",
+            name="range_change",
+            description="Range change",
             fillvalue=np.nan,
-            attrs={"units": "radians"},
+            attrs={"units": "meters"},
         )
 
     @classmethod
@@ -79,7 +79,7 @@ class DispProductInfo:
 class DispProductsInfo:
     """Container for instantiated displacement product dataset info containers."""
 
-    unwrapped_phase: DispProductInfo = DispProductInfo.unwrapped_phase()
+    range_change: DispProductInfo = DispProductInfo.range_change()
     connected_component_labels: DispProductInfo = (
         DispProductInfo.connected_component_labels()
     )

--- a/src/disp_s1/product_info.py
+++ b/src/disp_s1/product_info.py
@@ -20,11 +20,11 @@ class DispProductInfo:
 
     @classmethod
     def displacement(cls):
-        """Return container of range change specific information."""
+        """Return container of displacement specific information."""
         return cls(
             name="displacement",
             description=(
-                "Displacement (w/noise) in LOS. "
+                "Displacement with noise in Line-of-Sight (LOS). "
                 "Positive values indicate apparent motion towards the platform."
             ),
             fillvalue=np.nan,


### PR DESCRIPTION
These changes replace convert the unwrapped phase to range change and replace the current `unwrapped_phase` layer with `range_change` layer.

The test product header is as follows:

```
float range_change(y, x) ;
	range_change:_FillValue = NaNf ;
	string range_change:units = "meters" ;
	string range_change:long_name = "Range change" ;
	string range_change:grid_mapping = "spatial_ref" ;
```