### PR TITLE
Add `baseline` layer to product

### DIFF
--- a/.github/workflows/test-build-push.yml
+++ b/.github/workflows/test-build-push.yml
@@ -19,7 +19,7 @@ jobs:
           - label: Latest
             tag: "main"
           - label: Last Release
-            tag: v0.23.0
+            tag: v0.24.0
 
       fail-fast: true
     name: ${{ matrix.os }} • ${{ matrix.dolphin.label }}
@@ -42,7 +42,7 @@ jobs:
       - name: Install
         # TODO:  remove the `tqdm` once dolphin tqdm req is in conda
         run: |
-          python -m pip install tqdm "opera-utils>=0.10.0" git+https://github.com/isce-framework/dolphin@${{ matrix.dolphin.tag }}
+          python -m pip install tqdm "opera-utils>=0.11.0" git+https://github.com/isce-framework/dolphin@${{ matrix.dolphin.tag }}
           pip install --no-deps .
       - name: Install test dependencies
         run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,8 +69,8 @@ RUN micromamba install --yes --channel conda-forge -n base -f /tmp/specfile.txt 
 # https://github.com/mamba-org/micromamba-docker#running-commands-in-dockerfile-within-the-conda-environment
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 # --no-deps because they are installed with conda
-RUN pip install --no-deps git+https://github.com/isce-framework/dolphin@v0.18.0
-RUN pip install --no-deps git+https://github.com/opera-adt/opera-utils@v0.5.0
+RUN pip install --no-deps git+https://github.com/isce-framework/dolphin@v0.24.0
+RUN pip install --no-deps git+https://github.com/opera-adt/opera-utils@v0.11.0
 
 COPY --chown=$MAMBA_USER:$MAMBA_USER . .
 RUN python -m pip install --no-deps .

--- a/src/disp_s1/_baselines.py
+++ b/src/disp_s1/_baselines.py
@@ -1,0 +1,133 @@
+import isce3
+import numpy as np
+from dolphin import baseline
+from dolphin._types import Filename
+from numpy.typing import ArrayLike
+from opera_utils import (
+    get_cslc_orbit,
+    get_radar_wavelength,
+)
+from pyproj import CRS, Transformer
+
+
+def _get_grids(x: ArrayLike, y: ArrayLike, epsg: int) -> tuple:
+    X, Y = np.meshgrid(x, y)
+    xx = X.flatten()
+    yy = Y.flatten()
+    crs = CRS.from_epsg(epsg)
+    utm_to_lonlat = Transformer.from_crs(crs, CRS.from_epsg(4326), always_xy=True)
+    lon, lat = utm_to_lonlat.transform(xx=xx, yy=yy, radians=False)
+    lon = lon.reshape(X.shape)
+    lat = lat.reshape(Y.shape)
+    return lon, lat
+
+
+def compute_baselines(
+    h5file_ref: Filename,
+    h5file_sec: Filename,
+    x: ArrayLike,
+    y: ArrayLike,
+    epsg: int,
+    height: float = 0.0,
+    threshold: float = 1e-08,
+    maxiter: int = 50,
+    delta_range: float = 10.0,
+):
+    """Compute the perpendicular baseline at a subsampled grid for two CSLCs.
+
+    Parameters.
+    ----------
+    h5file_ref : Filename
+        Path to reference OPERA S1 CSLC HDF5 file.
+    h5file_sec : Filename
+        Path to secondary OPERA S1 CSLC HDF5 file.
+    height: float
+        Target height to use for baseline computation.
+        Default = 0.0
+    latlon_subsample: int
+        Factor by which to subsample the CSLC latitude/longitude grids.
+        Default = 30
+    threshold : float
+        isce3 geo2rdr: azimuth time convergence threshold in meters
+        Default = 1e-8
+    maxiter : int
+        isce3 geo2rdr: Maximum number of Newton-Raphson iterations
+        Default = 50
+    delta_range : float
+        isce3 geo2rdr: Step size used for computing derivative of doppler
+        Default = 10.0
+
+    Returns
+    -------
+    baselines : np.ndarray
+        2D array of perpendicular baselines
+
+    """
+    lon_grid, lat_grid = _get_grids(x=x, y=y, epsg=epsg)
+    lon_arr = lon_grid.ravel()
+    lat_arr = lat_grid.ravel()
+
+    ellipsoid = isce3.core.Ellipsoid()
+    zero_doppler = isce3.core.LUT2d()
+    wavelength = get_radar_wavelength(h5file_ref)
+    side = isce3.core.LookSide.Right
+
+    orbit_ref = get_cslc_orbit(h5file_ref)
+    orbit_sec = get_cslc_orbit(h5file_sec)
+
+    baselines = []
+    for lon, lat in zip(lon_arr, lat_arr):
+        llh_rad = np.deg2rad([lon, lat, height]).reshape((3, 1))
+        az_time_ref, range_ref = isce3.geometry.geo2rdr(
+            llh_rad,
+            ellipsoid,
+            orbit_ref,
+            zero_doppler,
+            wavelength,
+            side,
+            threshold=threshold,
+            maxiter=maxiter,
+            delta_range=delta_range,
+        )
+        az_time_sec, range_sec = isce3.geometry.geo2rdr(
+            llh_rad,
+            ellipsoid,
+            orbit_sec,
+            zero_doppler,
+            wavelength,
+            side,
+            threshold=threshold,
+            maxiter=maxiter,
+            delta_range=delta_range,
+        )
+
+        pos_ref, velocity = orbit_ref.interpolate(az_time_ref)
+        pos_sec, _ = orbit_sec.interpolate(az_time_sec)
+        b = baseline.compute(
+            llh_rad, pos_ref, pos_sec, range_ref, range_sec, velocity, ellipsoid
+        )
+
+        baselines.append(b)
+
+    return np.array(baselines).reshape(lon_grid.shape)
+
+
+def _interpolate_data(
+    data: np.ndarray, shape: tuple[int, int], method="linear"
+) -> np.ndarray:
+    from scipy.interpolate import RegularGridInterpolator
+
+    # Create coordinate arrays for the original data
+    orig_coords = [np.linspace(0, 1, s) for s in data.shape]
+
+    # Create coordinate arrays for the desired output shape
+    new_coords = [np.linspace(0, 1, s) for s in shape]
+
+    # Create the interpolator
+    interp = RegularGridInterpolator(orig_coords, data, method=method)
+
+    # Create a mesh grid for the new coordinates
+    mesh = np.meshgrid(*new_coords, indexing="xy")
+
+    # Perform the interpolation
+    return interp(np.array(mesh).T.astype("float32"))

--- a/src/disp_s1/main.py
+++ b/src/disp_s1/main.py
@@ -52,12 +52,8 @@ def run(
         wavelength_cutoff = 50_000
 
     # Finalize the output as an HDF5 product
-    # Group all the non-compressed SLCs by date
-    date_to_slcs = group_by_date(
-        [p for p in cfg.cslc_file_list if "compressed" not in p.name],
-        # We only care about the product date, not the Generation Date
-        date_idx=0,
-    )
+    # Group all the CSLCs by date to pick out ref/secondaries
+    date_to_cslc_files = group_by_date(cfg.cslc_file_list, date_idx=0)
 
     out_dir = pge_runconfig.product_path_group.output_directory
     out_dir.mkdir(exist_ok=True, parents=True)
@@ -83,9 +79,9 @@ def run(
     logger.info(f"Creating {len(out_paths.unwrapped_paths)} outputs in {out_dir}")
     create_displacement_products(
         out_paths,
-        out_dir,
-        date_to_slcs,
-        pge_runconfig,
+        out_dir=out_dir,
+        date_to_cslc_files=date_to_cslc_files,
+        pge_runconfig=pge_runconfig,
         wavelength_cutoff=wavelength_cutoff,
     )
     logger.info("Finished creating output products.")
@@ -133,7 +129,7 @@ class ProductFiles(NamedTuple):
 def process_product(
     files: ProductFiles,
     out_dir: Path,
-    date_to_slcs: Mapping[tuple[datetime], list[Path]],
+    date_to_cslc_files: Mapping[tuple[datetime], list[Path]],
     pge_runconfig: RunConfig,
     wavelength_cutoff: float,
 ) -> Path:
@@ -145,8 +141,8 @@ def process_product(
         NamedTuple containing paths for all displacement-related files.
     out_dir : Path
         Output directory for the product.
-    date_to_slcs: Mapping[tuple[datetime], list[Path]]
-        Dictionary mapping dates to corresponding CSLC files.
+    date_to_cslc_files: Mapping[tuple[datetime], list[Path]]
+        Dictionary mapping dates to real/compressed SLC files.
     pge_runconfig : RunConfig
         Configuration object for the PGE run.
     wavelength_cutoff : float
@@ -177,9 +173,13 @@ def process_product(
         )
 
     output_name = out_dir / files.unwrapped.with_suffix(".nc").name
-    dair_pair = get_dates(output_name)
-    secondary_date = dair_pair[1]
-    cur_slc_list = date_to_slcs[(secondary_date,)]
+    ref_date, secondary_date = get_dates(output_name)[:2]
+    # The reference one could be compressed, or real
+    # Also possible to have multiple compressed fiels with same reference date
+    ref_slc_files = date_to_cslc_files[(ref_date,)]
+    logger.debug(f"Found {len(ref_slc_files)} for reference date {ref_date}")
+    secondary_slc_files = date_to_cslc_files[(secondary_date,)]
+    assert len(secondary_slc_files) == 1
 
     product.create_output_product(
         output_name=output_name,
@@ -190,7 +190,8 @@ def process_product(
         ps_mask_filename=files.ps_mask,
         unwrapper_mask_filename=files.unwrapper_mask,
         pge_runconfig=pge_runconfig,
-        cslc_files=cur_slc_list,
+        reference_cslc_file=ref_slc_files[-1],
+        secondary_cslc_file=secondary_slc_files[0],
         corrections=corrections,
         wavelength_cutoff=wavelength_cutoff,
     )
@@ -201,7 +202,7 @@ def process_product(
 def create_displacement_products(
     out_paths: OutputPaths,
     out_dir: Path,
-    date_to_slcs: dict,
+    date_to_cslc_files: Mapping[tuple[datetime], list[Path]],
     pge_runconfig: RunConfig,
     wavelength_cutoff: float = 50_000.0,
     max_workers: int = 5,
@@ -214,8 +215,8 @@ def create_displacement_products(
         Object containing paths for various output files.
     out_dir : Path
         Output directory for the products.
-    date_to_slcs : dict
-        Dictionary mapping dates to corresponding SLC files.
+    date_to_cslc_files: Mapping[tuple[datetime], list[Path]]
+        Dictionary mapping dates to real/compressed SLC files.
     pge_runconfig : RunConfig
         Configuration object for the PGE run.
     wavelength_cutoff : float
@@ -260,7 +261,7 @@ def create_displacement_products(
                 process_product,
                 file,
                 out_dir,
-                date_to_slcs,
+                date_to_cslc_files,
                 pge_runconfig,
                 wavelength_cutoff,
             )

--- a/src/disp_s1/main.py
+++ b/src/disp_s1/main.py
@@ -177,9 +177,9 @@ def process_product(
     # The reference one could be compressed, or real
     # Also possible to have multiple compressed fiels with same reference date
     ref_slc_files = date_to_cslc_files[(ref_date,)]
-    logger.debug(f"Found {len(ref_slc_files)} for reference date {ref_date}")
+    logger.info(f"Found {len(ref_slc_files)} for reference date {ref_date}")
     secondary_slc_files = date_to_cslc_files[(secondary_date,)]
-    assert len(secondary_slc_files) == 1
+    logger.info(f"Found {len(secondary_slc_files)} for secondary date {secondary_date}")
 
     product.create_output_product(
         output_name=output_name,
@@ -190,7 +190,7 @@ def process_product(
         ps_mask_filename=files.ps_mask,
         unwrapper_mask_filename=files.unwrapper_mask,
         pge_runconfig=pge_runconfig,
-        reference_cslc_file=ref_slc_files[-1],
+        reference_cslc_file=ref_slc_files[0],
         secondary_cslc_file=secondary_slc_files[0],
         corrections=corrections,
         wavelength_cutoff=wavelength_cutoff,

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -695,14 +695,16 @@ def process_compressed_slc(info: CompressedSLCInfo) -> Path:
     return outname
 
 
-def copy_opera_cslc_metadata(comp_slc_file: Filename, outname: Filename) -> None:
+def copy_opera_cslc_metadata(
+    comp_slc_file: Filename, output_hdf5_file: Filename
+) -> None:
     """Copy orbit and metadata datasets from the input CSLC file the compressed SLC.
 
     Parameters
     ----------
     comp_slc_file : Filename
         Path to the input CSLC file.
-    outname : Filename
+    output_hdf5_file : Filename
         Path to the output compressed SLC file.
 
     """
@@ -710,10 +712,11 @@ def copy_opera_cslc_metadata(comp_slc_file: Filename, outname: Filename) -> None
         "/metadata/processing_information/input_burst_metadata/wavelength",
         "/identification/zero_doppler_end_time",
         "/identification/zero_doppler_start_time",
+        "/identification/bounding_polygon",
         "/metadata/orbit",  #          Group
     ]
 
-    with h5py.File(comp_slc_file, "r") as src, h5py.File(outname, "a") as dst:
+    with h5py.File(comp_slc_file, "r") as src, h5py.File(output_hdf5_file, "a") as dst:
         for dset_path in dsets_to_copy:
             if dset_path in src:
                 # Create parent group if it doesn't exist
@@ -734,7 +737,7 @@ def copy_opera_cslc_metadata(comp_slc_file: Filename, outname: Filename) -> None
                     f"Dataset or group {dset_path} not found in {comp_slc_file}"
                 )
 
-    logger.info(f"Copied metadata from {comp_slc_file} to {outname}")
+    logger.info(f"Copied metadata from {comp_slc_file} to {output_hdf5_file}")
 
 
 def create_compressed_products(

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -30,6 +30,7 @@ from opera_utils import (
 from tqdm.contrib.concurrent import process_map
 
 from . import __version__ as disp_s1_version
+from ._baselines import _interpolate_data, compute_baselines
 from ._common import DATETIME_FORMAT
 from .browse_image import make_browse_image_from_arr
 from .pge_runconfig import RunConfig
@@ -122,8 +123,11 @@ def create_output_product(
     """
     if corrections is None:
         corrections = {}
+
     crs = io.get_raster_crs(unw_filename)
     gt = io.get_raster_gt(unw_filename)
+    cols, rows = io.get_raster_xysize(unw_filename)
+    shape = (rows, cols)
 
     reference_start_time = get_zero_doppler_time(reference_cslc_file, type_="start")
     secondary_start_time = get_zero_doppler_time(secondary_cslc_file, type_="start")
@@ -133,19 +137,41 @@ def create_output_product(
     radar_wavelength = get_radar_wavelength(reference_cslc_file)
     phase2disp = -1 * float(radar_wavelength) / (4.0 * np.pi)
 
+    y, x = _create_yx_arrays(gt=gt, shape=shape)
+    # TODO: do we need all corrections/smaller grids to be same subsample factor?
+    subsample = 50
+    y, x = y[::subsample], x[::subsample]
+    try:
+        logger.info("Calculating perpendicular baselines subsampled by %s", subsample)
+        baseline_arr = compute_baselines(
+            reference_cslc_file,
+            secondary_cslc_file,
+            x=x,
+            y=y,
+            epsg=crs.to_epsg(),
+            height=0,
+        )
+    except Exception:
+        logger.error(
+            f"Failed to compute baselines for {reference_cslc_file},"
+            f" {secondary_cslc_file}",
+            exc_info=True,
+        )
+        baseline_arr = np.zeros((10, 10))
+    corrections["baseline"] = baseline_arr
+
+    logger.info("Extracting data footprint")
     try:
         footprint_wkt = extract_footprint(raster_path=unw_filename)
     except Exception:
         logger.error("Failed to extract raster footprint", exc_info=True)
         footprint_wkt = ""
-
     # Load and process unwrapped phase data, needs more custom masking
     unw_arr_ma = io.load_gdal(unw_filename, masked=True)
     unw_arr = np.ma.filled(unw_arr_ma, 0)
     mask = unw_arr == 0
 
     disp_arr = unw_arr * phase2disp
-    shape = unw_arr.shape
 
     _, x_res, _, _, _, y_res = gt
     # Average for the pixel spacing for filtering
@@ -314,6 +340,17 @@ def _create_corrections_group(
             description="Phase ramp caused by tectonic plate motion",
             fillvalue=np.nan,
             attrs={"units": "radians"},
+        )
+        baseline = corrections.get("baseline", empty_arr)
+        _create_geo_dataset(
+            group=corrections_group,
+            name="perpendicular_baseline",
+            data=_interpolate_data(baseline, shape=shape),
+            description=(
+                "Perpendicular baseline between reference and secondary acquisitions"
+            ),
+            fillvalue=np.nan,
+            attrs={"units": "meters"},
         )
         # Make a scalar dataset for the reference point
         reference_point = corrections.get("reference_point", 0.0)
@@ -517,13 +554,16 @@ def _create_geo_dataset(
     fillvalue: float,
     attrs: Optional[dict[str, Any]],
     include_time: bool = False,
+    x_name: str = "x",
+    y_name: str = "y",
+    grid_mapping_dset_name=GRID_MAPPING_DSET,
 ) -> h5netcdf.Variable:
     if include_time:
-        dimensions = ["time", "y", "x"]
+        dimensions = ["time", y_name, x_name]
         if data.ndim == 2:
             data = data[np.newaxis, :, :]
     else:
-        dimensions = ["y", "x"]
+        dimensions = [y_name, x_name]
     dset = _create_dataset(
         group=group,
         name=name,
@@ -533,7 +573,7 @@ def _create_geo_dataset(
         fillvalue=fillvalue,
         attrs=attrs,
     )
-    dset.attrs["grid_mapping"] = GRID_MAPPING_DSET
+    dset.attrs["grid_mapping"] = grid_mapping_dset_name
     return dset
 
 
@@ -558,21 +598,23 @@ def _create_yx_dsets(
     gt: list[float],
     shape: tuple[int, int],
     include_time: bool = False,
+    x_name: str = "x",
+    y_name: str = "y",
 ) -> tuple[h5netcdf.Variable, h5netcdf.Variable]:
     """Create the y, x, and coordinate datasets."""
     y, x = _create_yx_arrays(gt, shape)
 
     if not group.dimensions:
-        dims = {"y": y.size, "x": x.size}
+        dims = {y_name: y.size, x_name: x.size}
         if include_time:
             dims["time"] = 1
         group.dimensions = dims
 
     # Create the x/y datasets
-    y_ds = group.create_variable("y", ("y",), data=y, dtype=float)
-    x_ds = group.create_variable("x", ("x",), data=x, dtype=float)
+    y_ds = group.create_variable(y_name, (y_name,), data=y, dtype=float)
+    x_ds = group.create_variable(x_name, (x_name,), data=x, dtype=float)
 
-    for name, ds in zip(["y", "x"], [y_ds, x_ds]):
+    for name, ds in zip([y_name, x_name], [y_ds, x_ds]):
         ds.attrs["standard_name"] = f"projection_{name}_coordinate"
         ds.attrs["long_name"] = f"{name.replace('_', ' ')} coordinate of projection"
         ds.attrs["units"] = "m"
@@ -611,10 +653,12 @@ def _create_time_array(times: list[datetime.datetime]):
     return time, calendar, units
 
 
-def _create_grid_mapping(group, crs: pyproj.CRS, gt: list[float]) -> h5netcdf.Variable:
+def _create_grid_mapping(
+    group, crs: pyproj.CRS, gt: list[float], name: str = GRID_MAPPING_DSET
+) -> h5netcdf.Variable:
     """Set up the grid mapping variable."""
     # https://github.com/corteva/rioxarray/blob/21284f67db536d9c104aa872ab0bbc261259e59e/rioxarray/rioxarray.py#L34
-    dset = group.create_variable(GRID_MAPPING_DSET, (), data=0, dtype=int)
+    dset = group.create_variable(name, (), data=0, dtype=int)
 
     dset.attrs.update(crs.to_cf())
     # Also add the GeoTransform
@@ -669,12 +713,25 @@ def process_compressed_slc(info: CompressedSLCInfo) -> Path:
         ctype = h5py.h5t.py_create(np.complex64)
         ctype.commit(hf["/"].id, np.string_("complex64"))
 
+    # COMPASS used "_coordinates" instead of "x"/"y"
+    x_name, y_name = "x_coordinates", "y_coordinates"
+    grid_mapping_dset_name = "projection"
     with h5netcdf.File(outname, mode="a", invalid_netcdf=True) as f:
         f.attrs.update(attrs)
 
         data_group = f.create_group(group_name)
-        _create_grid_mapping(group=data_group, crs=crs, gt=gt)
-        _create_yx_dsets(group=data_group, gt=gt, shape=data.shape, include_time=False)
+        # COMPASS used "projection" instead of "spatial_ref"
+        _create_grid_mapping(
+            group=data_group, crs=crs, gt=gt, name=grid_mapping_dset_name
+        )
+        _create_yx_dsets(
+            group=data_group,
+            gt=gt,
+            shape=data.shape,
+            include_time=False,
+            x_name=x_name,
+            y_name=y_name,
+        )
         _create_geo_dataset(
             group=data_group,
             name=dset_name,
@@ -682,6 +739,9 @@ def process_compressed_slc(info: CompressedSLCInfo) -> Path:
             description="Compressed SLC product",
             fillvalue=np.nan + 0j,
             attrs=attrs,
+            x_name=x_name,
+            y_name=y_name,
+            grid_mapping_dset_name=grid_mapping_dset_name,
         )
         del data
 
@@ -695,6 +755,9 @@ def process_compressed_slc(info: CompressedSLCInfo) -> Path:
             description="Amplitude dispersion for the compressed SLC files.",
             fillvalue=np.nan,
             attrs={"units": "unitless"},
+            x_name=x_name,
+            y_name=y_name,
+            grid_mapping_dset_name=grid_mapping_dset_name,
         )
 
     copy_opera_cslc_metadata(opera_cslc_file, outname)

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -157,8 +157,8 @@ def create_output_product(
             f" {secondary_cslc_file}",
             exc_info=True,
         )
-        baseline_arr = np.zeros((10, 10))
-    corrections["baseline"] = baseline_arr
+        baseline_arr = np.zeros((100, 100))
+    corrections["baseline"] = _interpolate_data(baseline_arr, shape=shape)
 
     logger.info("Extracting data footprint")
     try:
@@ -345,7 +345,7 @@ def _create_corrections_group(
         _create_geo_dataset(
             group=corrections_group,
             name="perpendicular_baseline",
-            data=_interpolate_data(baseline, shape=shape),
+            data=baseline,
             description=(
                 "Perpendicular baseline between reference and secondary acquisitions"
             ),


### PR DESCRIPTION
New layer looks like this
![image](https://github.com/user-attachments/assets/582a21f2-d71c-4678-aee1-8f184bd06cab)

I've included in `corrections/` for now, since I'm assuming we want this in order to compute other corrections in the future (e.g. DEM error)

- Refactor with `date_to_slcs` happened due to the additional metadata in the compressed HDF5 products now
- For now, we're only passing through one burst's CSLC file to grab metadata (the timing may be not fully accurate then?)
- More updates to make CCSLCs match the CSLC structure (`x_coordinates`, not `x`)