### PR TITLE
Convert the tolerance for comparing displacement to meters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,6 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
-        - types-pkg_resources
+        - types-setuptools
         - types-requests
         - "pydantic>=2.4"

--- a/src/disp_s1/cli/validate.py
+++ b/src/disp_s1/cli/validate.py
@@ -1,4 +1,5 @@
 import click
+from dolphin import setup_logging
 
 from disp_s1.validate import DSET_DEFAULT, compare
 
@@ -7,6 +8,8 @@ from disp_s1.validate import DSET_DEFAULT, compare
 @click.argument("golden", type=click.Path(exists=True))
 @click.argument("test", type=click.Path(exists=True))
 @click.option("--data-dset", default=DSET_DEFAULT)
-def validate(golden: str, test: str, data_dset: str) -> None:
+@click.option("--debug", is_flag=True)
+def validate(golden: str, test: str, data_dset: str, debug: bool) -> None:
     """Compare two HDF4 files for consistency."""
+    setup_logging(logger_name="disp_s1", debug=debug, filename=None)
     compare(golden, test, data_dset)

--- a/src/disp_s1/validate.py
+++ b/src/disp_s1/validate.py
@@ -401,8 +401,13 @@ def _validate_dataset(
     golden = golden_dataset[()]
     test = test_dataset[()]
     if golden.dtype.kind == "S":
+        if "version" in golden_dataset.name:
+            logger.info(f"{golden_dataset.name}: {golden} vs. {test}")
+            return
         if not np.array_equal(golden, test):
-            raise ComparisonError(f"Dataset {golden_dataset.name} values do not match")
+            msg = f"Dataset {golden_dataset.name} values do not match:"
+            msg += f" {golden = } vs. {test = }"
+            raise ComparisonError(msg)
         return
 
     img_gold = np.ma.masked_invalid(golden)

--- a/src/disp_s1/validate.py
+++ b/src/disp_s1/validate.py
@@ -260,7 +260,7 @@ def _validate_displacement(
         connected component label). Must be in the interval [0, 1]. Defaults to 0.01.
     atol : float, optional
         Maximum allowable absolute error between the re-wrapped reference and test
-        values, in meters. Must be nonnegative. Defaults to 1e-6.
+        values, in meters. Must be nonnegative. Defaults to 1e-5.
     wavelength : float, optional
         Sensor wavelength to convert displacement to phase and rewrap.
         Default is Sentinel-1 wavelength (speed of light / center frequency).

--- a/src/disp_s1/validate.py
+++ b/src/disp_s1/validate.py
@@ -236,7 +236,7 @@ def _validate_displacement(
     test_conncomps: ArrayLike,
     ref_conncomps: ArrayLike,
     nan_threshold: float = 0.01,
-    atol: float = 1e-6,
+    atol: float = 1e-5,
     wavelength: float = 299_792_458 / 5.405e9,
 ) -> None:
     """Validate displacement values against a reference dataset.
@@ -260,9 +260,10 @@ def _validate_displacement(
         connected component label). Must be in the interval [0, 1]. Defaults to 0.01.
     atol : float, optional
         Maximum allowable absolute error between the re-wrapped reference and test
-        values, in radians. Must be nonnegative. Defaults to 1e-6.
-    wavelength : float
-        sensor wavelength to convert displacement to phase and rewrap
+        values, in meters. Must be nonnegative. Defaults to 1e-6.
+    wavelength : float, optional
+        Sensor wavelength to convert displacement to phase and rewrap.
+        Default is Sentinel-1 wavelength (speed of light / center frequency).
 
     Raises
     ------
@@ -355,7 +356,8 @@ def _validate_displacement(
     logger.info(f"Mean absolute re-wrapped phase error: {mean_abs_err:.5f} rad")
     logger.info(f"Max absolute re-wrapped phase error: {max_abs_err:.5f} rad")
 
-    noncongruent_count = np.sum(abs_wrapped_diff > atol)
+    atol_radians = atol * 4 * np.pi / wavelength
+    noncongruent_count = np.sum(abs_wrapped_diff > atol_radians)
     logger.info(
         "Non-congruent pixel count:"
         f" {_fmt_ratio(noncongruent_count, wrapped_diff.size)}"


### PR DESCRIPTION
Makes the tolerance 1e-5 as well.

I added the logging because we never set the handlers/level for `disp-s1 validate` like we do in `disp-s1 run`