### PR TITLE
Add recommended mask, add `long_name`s, fix output for network unwrapping approaches

### DIFF
--- a/src/disp_s1/main.py
+++ b/src/disp_s1/main.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime
 from itertools import repeat
@@ -9,10 +9,12 @@ from multiprocessing import get_context
 from pathlib import Path
 from typing import NamedTuple
 
+from dolphin import interferogram
 from dolphin._log import log_runtime, setup_logging
 from dolphin.io import load_gdal
+from dolphin.unwrap import grow_conncomp_snaphu
 from dolphin.utils import DummyProcessPoolExecutor, full_suffix, get_max_memory_usage
-from dolphin.workflows.config import DisplacementWorkflow
+from dolphin.workflows.config import DisplacementWorkflow, UnwrapOptions
 from dolphin.workflows.displacement import OutputPaths
 from dolphin.workflows.displacement import run as run_displacement
 from opera_utils import get_dates, group_by_date
@@ -59,11 +61,11 @@ def run(
     # Run dolphin's displacement workflow
     out_paths = run_displacement(cfg=cfg, debug=debug)
 
-    # Create the short wavelength layer for the product
+    # Ensure the wavelength is set for the short wavelength layer
     if hasattr(cfg, "spatial_wavelength_cutoff"):
         wavelength_cutoff = cfg.spatial_wavelength_cutoff
     else:
-        wavelength_cutoff = 50_000
+        wavelength_cutoff = 25_000
 
     # Read the reference point
     assert out_paths.timeseries_paths is not None
@@ -84,25 +86,45 @@ def run(
     out_dir.mkdir(exist_ok=True, parents=True)
     logger.info(f"Creating {len(out_paths.timeseries_paths)} outputs in {out_dir}")
 
-    # group dataset based on date to find corresponding files and set None
-    # for the layers that do not exist: correction layers specifically
-    # grouped_unwrapped_paths = group_by_date(out_paths.timeseries_paths)
-    # TODO: what goes wrong if we pick unw, not timeseries?
-    # TODO: how can we get conncomps when we do nearest 3, and invert?
-    # TODO: the iono paths will have come from `timeseries`, and will be wrong
-    grouped_unwrapped_paths = group_by_date(out_paths.unwrapped_paths)
-    unw_date_keys = list(grouped_unwrapped_paths.keys())
-    _assert_dates_match(unw_date_keys, out_paths.conncomp_paths, "connected components")
-    _assert_dates_match(unw_date_keys, out_paths.stitched_cor_paths, "correlation")
+    # Check for a network unwrapping approach:
+    grouped_timeseries_paths = group_by_date(out_paths.timeseries_paths)
+    disp_date_keys = set(grouped_timeseries_paths.keys())
 
-    if out_paths.tropospheric_corrections is not None:
-        _assert_dates_match(
-            unw_date_keys, out_paths.tropospheric_corrections, "troposphere"
+    # Check and update correlation paths
+    if set(group_by_date(out_paths.stitched_cor_paths).keys()) != disp_date_keys:
+        out_paths.stitched_cor_paths = (
+            interferogram.estimate_interferometric_correlations(
+                ifg_filenames=out_paths.timeseries_paths,
+                window_size=(11, 11),
+            )
         )
 
+    # Check and update connected components paths
+    if set(group_by_date(out_paths.conncomp_paths).keys()) != disp_date_keys:
+        method = cfg.unwrap_options.unwrap_method
+        if method == "snaphu":
+            out_paths.conncomp_paths = _update_snaphu_conncomps(
+                out_paths.timeseries_paths, out_paths, cfg
+            )
+        elif method == "spurt":
+            out_paths.conncomp_paths = _update_spurt_conncomps(
+                out_paths.conncomp_paths, out_paths.timeseries_paths
+            )
+        else:
+            raise NotImplementedError(
+                f"Regrowing connected components not implemented for {method}"
+            )
+
+    # Check tropospheric corrections
+    if out_paths.tropospheric_corrections is not None:
+        _assert_dates_match(
+            disp_date_keys, out_paths.tropospheric_corrections, "troposphere"
+        )
+
+    # Check ionospheric corrections
     if out_paths.ionospheric_corrections is not None:
         _assert_dates_match(
-            unw_date_keys, out_paths.ionospheric_corrections, "ionosphere"
+            disp_date_keys, out_paths.ionospheric_corrections, "ionosphere"
         )
 
     logger.info(f"Creating {len(out_paths.timeseries_paths)} outputs in {out_dir}")
@@ -138,11 +160,28 @@ def run(
 
 
 def _assert_dates_match(
-    unw_date_keys: list[datetime], test_paths: list[Path], name: str
-):
-    if list(group_by_date(test_paths).keys()) != unw_date_keys:
+    disp_date_keys: set[datetime], test_paths: Iterable[Path], name: str
+) -> None:
+    """Assert that the dates in `paths_to_check` match the reference dates.
+
+    Parameters
+    ----------
+    disp_date_keys : list[str]
+        list of reference dates to compare against.
+    test_paths : list[Path]
+        list of paths to check for date consistency.
+    name : str
+        Description of the paths being checked (for error message).
+
+    Raises
+    ------
+    AssertionError
+        If the dates in the paths to check do not match the reference dates.
+
+    """
+    if set(group_by_date(test_paths).keys()) != disp_date_keys:
         msg = f"Mismatch of dates found for {name}:"
-        msg += f"{unw_date_keys = }, but {name} has {test_paths}"
+        msg += f"{disp_date_keys = }, but {name} has {test_paths}"
         raise ValueError(msg)
 
 
@@ -262,7 +301,7 @@ def create_displacement_products(
     reference_point: ReferencePoint | None = None,
     los_east_file: Path | None = None,
     los_north_file: Path | None = None,
-    max_workers: int = 3,
+    max_workers: int = 1,
 ) -> None:
     """Run parallel processing for all interferograms.
 
@@ -323,8 +362,7 @@ def create_displacement_products(
             unwrapper_mask=mask_f,
         )
         for unw, cc, cor, tropo, iono, mask_f in zip(
-            # out_paths.timeseries_paths,
-            out_paths.unwrapped_paths,
+            out_paths.timeseries_paths,
             out_paths.conncomp_paths,
             out_paths.stitched_cor_paths,
             tropo_files,
@@ -352,3 +390,67 @@ def create_displacement_products(
                 repeat(los_north_file),
             )
         )
+
+
+def _update_snaphu_conncomps(
+    timeseries_paths: Sequence[Path],
+    out_paths: OutputPaths,
+    unwrap_options: UnwrapOptions,
+) -> list[Path]:
+    """Update connected components using SNAPHU unwrapping method.
+
+    Parameters
+    ----------
+    timeseries_paths : list[Path]
+        list of paths to the timeseries files.
+    out_paths : OutPaths
+        Object containing various output paths.
+    unwrap_options : [dolphin.workflows.config.UnwrapOptions][]
+        Configuration object containing unwrapping options.
+
+    Returns
+    -------
+    list[Path]
+        list of updated connected component paths.
+
+    """
+    new_paths = []
+    for unw_f, cor_f in zip(timeseries_paths, out_paths.stitched_cor_paths):
+        mask_file = Path(str(cor_f).replace(".cor.tif", ".mask.tif"))
+        new_path = grow_conncomp_snaphu(
+            unw_filename=unw_f,
+            corr_filename=cor_f,
+            nlooks=50,
+            mask_filename=mask_file,
+            cost=unwrap_options.snaphu_options.cost,
+            scratchdir=unwrap_options._directory / "scratch2",
+        )
+        new_paths.append(new_path)
+    return new_paths
+
+
+def _update_spurt_conncomps(
+    conncomp_paths: Sequence[Path], timeseries_paths: Sequence[Path]
+) -> list[Path]:
+    """Update connected components using SPURT unwrapping method.
+
+    Parameters
+    ----------
+    conncomp_paths : list[Path]
+        list of original connected component paths.
+    timeseries_paths : list[Path]
+        list of paths to the timeseries files.
+
+    Returns
+    -------
+    list[Path]
+        list of updated connected component paths.
+
+    """
+    new_conncomp_paths: list[Path] = []
+    for cc_p, ts_p in zip(conncomp_paths, timeseries_paths, strict=False):
+        new_name = cc_p.parent / str(ts_p.name).replace(
+            full_suffix(ts_p), full_suffix(cc_p)
+        )
+        new_conncomp_paths.append(cc_p.rename(new_name))
+    return new_conncomp_paths

--- a/src/disp_s1/main.py
+++ b/src/disp_s1/main.py
@@ -301,7 +301,7 @@ def create_displacement_products(
     reference_point: ReferencePoint | None = None,
     los_east_file: Path | None = None,
     los_north_file: Path | None = None,
-    max_workers: int = 1,
+    max_workers: int = 3,
 ) -> None:
     """Run parallel processing for all interferograms.
 

--- a/src/disp_s1/pge_runconfig.py
+++ b/src/disp_s1/pge_runconfig.py
@@ -295,8 +295,10 @@ class RunConfig(YamlModel):
         param_dict["output_options"]["bounds_epsg"] = bounds_epsg
         # Always turn off overviews (won't be saved in the HDF5 anyway)
         param_dict["output_options"]["add_overviews"] = False
-        # Always turn off velocity (not used)
+        # Always turn off velocity (not used) in output product
         param_dict["timeseries_options"]["run_velocity"] = False
+        # Always use L1 minimization for inverting unwrapped networks
+        param_dict["timeseries_options"]["method"] = "L1"
 
         # Get the current set of expected reference dates
         reference_datetimes = _parse_reference_date_json(

--- a/src/disp_s1/pge_runconfig.py
+++ b/src/disp_s1/pge_runconfig.py
@@ -272,10 +272,10 @@ class RunConfig(YamlModel):
             self.static_ancillary_file_group.algorithm_parameters_overrides_json,
             frame_id,
         )
-        # Override the dict, but then convert back to get all the defaults in again
-        param_dict = AlgorithmParameters(**(param_dict | override_params)).model_dump()
-
-        input_options = {"subdataset": param_dict.pop("subdataset")}
+        # Override the dict,
+        param_dict = _nested_update(param_dict, override_params)
+        # but then convert back to ensure all defaults remained in `param_dict`
+        param_dict = AlgorithmParameters(**param_dict).model_dump()
 
         # Convert the frame_id into an output bounding box
         frame_to_burst_file = self.static_ancillary_file_group.frame_to_burst_json
@@ -290,6 +290,7 @@ class RunConfig(YamlModel):
         if mismatched_bursts:
             raise ValueError("The CSLC data and frame id do not match")
 
+        input_options = {"subdataset": param_dict.pop("subdataset")}
         param_dict["output_options"]["bounds"] = bounds
         param_dict["output_options"]["bounds_epsg"] = bounds_epsg
         # Always turn off overviews (won't be saved in the HDF5 anyway)
@@ -463,3 +464,12 @@ def _parse_algorithm_overrides(
             else:
                 return overrides.get(str(frame_id), {})
     return {}
+
+
+def _nested_update(base: dict, updates: dict):
+    for k, v in updates.items():
+        if isinstance(v, dict):
+            base[k] = _nested_update(base.get(k, {}), v)
+        else:
+            base[k] = v
+    return base

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -693,7 +693,9 @@ def _create_dataset(
 ) -> h5netcdf.Variable:
     if attrs is None:
         attrs = {}
-    attrs.update(description=description, long_name=long_name)
+    attrs.update(description=description)
+    if long_name:
+        attrs["long_name"] = long_name
 
     options = HDF5_OPTS
     if isinstance(data, str):

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -1040,7 +1040,7 @@ def create_compressed_products(
     comp_slc_dict: Mapping[str, Sequence[Path]],
     output_dir: Filename,
     cslc_file_list: Sequence[Path],
-    max_workers: int = 2,
+    max_workers: int = 3,
 ) -> list[Path]:
     """Create all compressed SLC output products.
 

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -225,12 +225,16 @@ def create_output_product(
         "Creating short wavelength displacement product with %s meter cutoff",
         wavelength_cutoff,
     )
-    bad_corr = io.load_gdal(ifg_corr_filename) < 0.5
     conncomps = io.load_gdal(conncomp_filename, masked=True).filled(0)
     bad_conncomp = conncomps == 0
+
+    temporal_coherence = io.load_gdal(temp_coh_filename, masked=True).mean()
+    bad_temporal_coherence = temporal_coherence < 0.5
+    bad_pixel_mask = bad_temporal_coherence | bad_conncomp
+
     filtered_disp_arr = filtering.filter_long_wavelength(
         unwrapped_phase=disp_arr,
-        bad_pixel_mask=bad_corr | bad_conncomp,
+        bad_pixel_mask=bad_pixel_mask,
         wavelength_cutoff=wavelength_cutoff,
         pixel_spacing=pixel_spacing,
     ).astype(np.float32)
@@ -241,8 +245,7 @@ def create_output_product(
     disp_arr[mask] = np.nan
     filtered_disp_arr[mask] = np.nan
 
-    # TODO: Make the "recommended mask" here
-    recommended_mask = ~bad_conncomp
+    recommended_mask = ~bad_pixel_mask
 
     product_infos: list[ProductInfo] = list(DISPLACEMENT_PRODUCTS)
 
@@ -262,6 +265,7 @@ def create_output_product(
                 group=f,
                 name=info.name,
                 data=data,
+                long_name=info.long_name,
                 description=info.description,
                 fillvalue=info.fillvalue,
                 attrs=info.attrs,
@@ -277,9 +281,20 @@ def create_output_product(
         )
         del disp_arr
         del filtered_disp_arr
+        info = product_infos[2]
+        _create_geo_dataset(
+            group=f,
+            name=info.name,
+            data=recommended_mask,
+            description=info.description,
+            long_name=info.long_name,
+            fillvalue=info.fillvalue,
+            attrs=info.attrs,
+        )
 
         # For the others, load and save each individually
         data_files = [
+            conncomp_filename,
             conncomp_filename,
             temp_coh_filename,
             ifg_corr_filename,
@@ -288,7 +303,7 @@ def create_output_product(
             unwrapper_mask_filename,
         ]
 
-        for info, filename in zip(product_infos[2:], data_files):
+        for info, filename in zip(product_infos[3:], data_files):
             if filename is not None and Path(filename).exists():
                 data = io.load_gdal(filename).astype(info.dtype)
             else:
@@ -302,6 +317,7 @@ def create_output_product(
                 name=info.name,
                 data=data,
                 description=info.description,
+                long_name=info.long_name,
                 fillvalue=info.fillvalue,
                 attrs=info.attrs,
             )
@@ -337,8 +353,7 @@ def create_output_product(
     )
 
     # Get summary statistics on the layers for CMR filtering/searching purposes
-    average_temporal_coherence = io.load_gdal(temp_coh_filename, masked=True).mean()
-
+    average_temporal_coherence = temporal_coherence.mean()
     _create_identification_group(
         output_name=output_name,
         pge_runconfig=pge_runconfig,
@@ -400,6 +415,7 @@ def _create_corrections_group(
         _create_geo_dataset(
             group=corrections_group,
             name="tropospheric_delay",
+            long_name="Tropospheric Delay",
             data=troposphere,
             description="Tropospheric phase delay used to correct the unwrapped phase",
             fillvalue=np.nan,
@@ -409,6 +425,7 @@ def _create_corrections_group(
         _create_geo_dataset(
             group=corrections_group,
             name="ionospheric_delay",
+            long_name="Ionospheric Delay",
             data=ionosphere,
             description="Ionospheric phase delay used to correct the unwrapped phase",
             fillvalue=np.nan,
@@ -418,6 +435,7 @@ def _create_corrections_group(
         _create_geo_dataset(
             group=corrections_group,
             name="solid_earth_tide",
+            long_name="Solid Earth Tide",
             data=solid_earth,
             description="Solid Earth tide used to correct the unwrapped phase",
             fillvalue=np.nan,
@@ -427,6 +445,7 @@ def _create_corrections_group(
         _create_geo_dataset(
             group=corrections_group,
             name="perpendicular_baseline",
+            long_name="Perpendicular Baseline",
             data=baseline,
             description=(
                 "Perpendicular baseline between reference and secondary acquisitions"
@@ -666,12 +685,13 @@ def _create_dataset(
     data: Union[np.ndarray, str],
     description: str,
     fillvalue: Optional[float],
+    long_name: str | None = None,
     attrs: Optional[dict[str, Any]] = None,
     dtype: Optional[DTypeLike] = None,
 ) -> h5netcdf.Variable:
     if attrs is None:
         attrs = {}
-    attrs.update(long_name=description)
+    attrs.update(description=description, long_name=long_name)
 
     options = HDF5_OPTS
     if isinstance(data, str):
@@ -698,6 +718,7 @@ def _create_geo_dataset(
     group: h5netcdf.Group,
     name: str,
     data: np.ndarray,
+    long_name: str,
     description: str,
     fillvalue: float,
     attrs: Optional[dict[str, Any]],
@@ -717,6 +738,7 @@ def _create_geo_dataset(
         name=name,
         dimensions=dimensions,
         data=data,
+        long_name=long_name,
         description=description,
         fillvalue=fillvalue,
         attrs=attrs,
@@ -884,6 +906,7 @@ def process_compressed_slc(info: CompressedSLCInfo) -> Path:
             group=data_group,
             name=dset_name,
             data=data,
+            long_name="Compressed SLC",
             description="Compressed SLC product",
             fillvalue=np.nan + 0j,
             attrs=attrs,
@@ -900,6 +923,7 @@ def process_compressed_slc(info: CompressedSLCInfo) -> Path:
             group=data_group,
             name=dispersion_dset_name,
             data=amp_dispersion_data,
+            long_name="Amplitude Dispersion",
             description="Amplitude dispersion for the compressed SLC files.",
             fillvalue=np.nan,
             attrs={"units": "unitless"},

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -281,11 +281,13 @@ def create_output_product(
         )
         del disp_arr
         del filtered_disp_arr
+
+        # Add the recommended mask, which is already loaded
         info = product_infos[2]
         _create_geo_dataset(
             group=f,
             name=info.name,
-            data=recommended_mask,
+            data=recommended_mask.astype("uint8"),
             description=info.description,
             long_name=info.long_name,
             fillvalue=info.fillvalue,

--- a/src/disp_s1/product_info.py
+++ b/src/disp_s1/product_info.py
@@ -10,6 +10,7 @@ class ProductInfo:
     """Information about a displacement product dataset."""
 
     name: str
+    long_name: str
     description: str
     fillvalue: DTypeLike
     dtype: DTypeLike
@@ -24,8 +25,9 @@ class DisplacementProducts:
     displacement: ProductInfo = field(
         default_factory=lambda: ProductInfo(
             name="displacement",
+            long_name="Line-of-sight displacement",
             description=(
-                "Displacement with noise in Line-of-Sight (LOS)."
+                "Displacement along the radar Line-of-Sight (LOS) direction."
                 " Positive values indicate apparent motion towards the platform."
             ),
             fillvalue=np.nan,
@@ -40,6 +42,7 @@ class DisplacementProducts:
     short_wavelength_displacement: ProductInfo = field(
         default_factory=lambda: ProductInfo(
             name="short_wavelength_displacement",
+            long_name="Short wavelength displacement",
             description=(
                 "Displacement in Line-of-Sight (LOS) with long-wavelength signals"
                 " removed. Positive values indicate apparent motion towards the"
@@ -53,9 +56,23 @@ class DisplacementProducts:
             dtype=np.float32,
         )
     )
+    recommended_mask: ProductInfo = field(
+        default_factory=lambda: ProductInfo(
+            name="recommended_mask",
+            long_name="Recommended Mask",
+            description=(
+                "Suggested mask to remove low quality pixels, where 0 indicates a bad"
+                " pixel, 1 is a good pixel"
+            ),
+            fillvalue=255,
+            attrs={"units": "unitless"},
+            dtype=np.uint8,
+        )
+    )
     connected_component_labels: ProductInfo = field(
         default_factory=lambda: ProductInfo(
             name="connected_component_labels",
+            long_name="Connected Component Labels",
             description="Connected component labels of the unwrapped phase",
             fillvalue=DEFAULT_CCL_NODATA,
             attrs={"units": "unitless"},
@@ -65,6 +82,7 @@ class DisplacementProducts:
     temporal_coherence: ProductInfo = field(
         default_factory=lambda: ProductInfo(
             name="temporal_coherence",
+            long_name="Temporal Coherence",
             description="Temporal coherence of phase inversion",
             fillvalue=np.nan,
             attrs={"units": "unitless"},
@@ -75,11 +93,9 @@ class DisplacementProducts:
     )
     interferometric_correlation: ProductInfo = field(
         default_factory=lambda: ProductInfo(
-            name="interferometric_correlation",
-            description=(
-                "Estimate of interferometric correlation derived from multilooked"
-                " interferogram."
-            ),
+            name="estimated_spatial_coherence",
+            long_name="Estimated spatial coherence",
+            description="Sliding window estimator of multi-looked phase noise",
             fillvalue=np.nan,
             attrs={"units": "unitless"},
             # 8 bits (between 0 and 1) is around .001 precision
@@ -90,9 +106,10 @@ class DisplacementProducts:
     persistent_scatterer_mask: ProductInfo = field(
         default_factory=lambda: ProductInfo(
             name="persistent_scatterer_mask",
+            long_name="Persistent Scatterer Mask",
             description=(
                 "Mask of persistent scatterers downsampled to the multilooked output"
-                " grid."
+                " grid"
             ),
             fillvalue=255,
             attrs={"units": "unitless"},
@@ -102,9 +119,10 @@ class DisplacementProducts:
     shp_counts: ProductInfo = field(
         default_factory=lambda: ProductInfo(
             name="shp_counts",
+            long_name="Statistically Homogeneous Pixels Counts",
             description=(
-                "Number of statistically homogeneous pixels (SHPs) used during"
-                " multilooking."
+                "Number of statistically homogeneous pixels (SHPs) used at each output"
+                " pixel during multilooking"
             ),
             fillvalue=0,
             attrs={"units": "unitless"},
@@ -114,7 +132,8 @@ class DisplacementProducts:
     unwrapper_mask: ProductInfo = field(
         default_factory=lambda: ProductInfo(
             name="unwrapper_mask",
-            description="Mask used during phase unwrapping to ignore input pixels.",
+            long_name="Unwrapper Mask",
+            description="Mask used during phase unwrapping to ignore input pixels",
             fillvalue=255,
             attrs={"units": "unitless"},
             dtype=np.uint8,


### PR DESCRIPTION
- Fixes the long-standing TODO for how to deal with different correlations if we unwrap a network. Conncomps are still todo
- Adds the `recommended_mask` to product. May adjust exact logic to produce this later
- Uses `long_name` for more user friendly plots instead of just the description (which is too long for normal plotting text)