### PR TITLE
Add `phase_similarity` raster, add water masking to `recommended_mask`

### DIFF
--- a/src/disp_s1/main.py
+++ b/src/disp_s1/main.py
@@ -47,22 +47,25 @@ def run(
 
     """
     setup_logging(logger_name="disp_s1", debug=debug, filename=cfg.log_file)
+    cfg.work_directory.mkdir(exist_ok=True, parents=True)
     # Setup the binary mask as dolphin expects
     if pge_runconfig.dynamic_ancillary_file_group.mask_file:
         water_binary_mask = cfg.work_directory / "water_binary_mask.tif"
         create_mask_from_distance(
             water_distance_file=pge_runconfig.dynamic_ancillary_file_group.mask_file,
             output_file=water_binary_mask,
+            # Set a little conservative for the general processing
             land_buffer=2,
             ocean_buffer=2,
         )
         cfg.mask_file = water_binary_mask
+
         aggressive_water_binary_mask = (
             cfg.work_directory / "water_binary_mask_nobuffer.tif"
         )
         create_mask_from_distance(
             water_distance_file=pge_runconfig.dynamic_ancillary_file_group.mask_file,
-            output_file=water_binary_mask,
+            output_file=aggressive_water_binary_mask,
             # Still don't trust the land water 100%
             land_buffer=1,
             # Trust the ocean buffer

--- a/src/disp_s1/main.py
+++ b/src/disp_s1/main.py
@@ -197,6 +197,7 @@ class ProductFiles(NamedTuple):
     troposphere: Path | None
     ionosphere: Path | None
     unwrapper_mask: Path | None
+    similarity: Path
 
 
 def process_product(
@@ -277,6 +278,7 @@ def process_product(
         ps_mask_filename=files.ps_mask,
         shp_count_filename=files.shp_counts,
         unwrapper_mask_filename=files.unwrapper_mask,
+        similarity_filename=files.similarity,
         los_east_file=los_east_file,
         los_north_file=los_north_file,
         pge_runconfig=pge_runconfig,
@@ -297,7 +299,7 @@ def create_displacement_products(
     date_to_cslc_files: Mapping[tuple[datetime], list[Path]],
     pge_runconfig: RunConfig,
     dolphin_config: DisplacementWorkflow,
-    wavelength_cutoff: float = 50_000.0,
+    wavelength_cutoff: float = 25_000.0,
     reference_point: ReferencePoint | None = None,
     los_east_file: Path | None = None,
     los_north_file: Path | None = None,
@@ -322,7 +324,7 @@ def create_displacement_products(
         If None, will record empty in the dataset's attributes
     wavelength_cutoff : float
         Wavelength cutoff (in meters) for filtering long wavelengths.
-        Default is 50_000.
+        Default is 25_000.
     reference_point : ReferencePoint, optional
         Reference point recorded from dolphin after unwrapping.
         If none, leaves product attributes empty.
@@ -360,6 +362,7 @@ def create_displacement_products(
             troposphere=tropo,
             ionosphere=iono,
             unwrapper_mask=mask_f,
+            similarity=out_paths.stitched_similarity_file,
         )
         for unw, cc, cor, tropo, iono, mask_f in zip(
             out_paths.timeseries_paths,
@@ -371,6 +374,7 @@ def create_displacement_products(
         )
     ]
 
+    max_workers = 1
     executor_class = (
         ProcessPoolExecutor if max_workers > 1 else DummyProcessPoolExecutor
     )

--- a/src/disp_s1/main.py
+++ b/src/disp_s1/main.py
@@ -396,7 +396,6 @@ def create_displacement_products(
         )
     ]
 
-    max_workers = 1
     executor_class = (
         ProcessPoolExecutor if max_workers > 1 else DummyProcessPoolExecutor
     )

--- a/src/disp_s1/pge_runconfig.py
+++ b/src/disp_s1/pge_runconfig.py
@@ -191,7 +191,7 @@ class AlgorithmParameters(YamlModel):
         description="Name of the subdataset to use in the input NetCDF files.",
     )
     spatial_wavelength_cutoff: float = Field(
-        50_000,
+        25_000,
         description=(
             "Spatial wavelength cutoff (in meters) for the spatial filter. Used to"
             " create the short wavelength displacement layer"

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -95,7 +95,7 @@ def create_output_product(
     los_north_file: Filename | None = None,
     reference_point: ReferencePoint | None = None,
     corrections: Optional[dict[str, ArrayLike]] = None,
-    wavelength_cutoff: float = 50_000.0,
+    wavelength_cutoff: float = 25_000.0,
 ):
     """Create the OPERA output product in NetCDF format.
 
@@ -143,7 +143,7 @@ def create_output_product(
         A dictionary of corrections to write to the output file, by default None
     wavelength_cutoff : float, optional
         The wavelength cutoff for filtering long wavelengths.
-        Default is 50_000.0
+        Default is 25_000.0
 
 
     """

--- a/src/disp_s1/product_info.py
+++ b/src/disp_s1/product_info.py
@@ -139,6 +139,21 @@ class DisplacementProducts:
             dtype=np.uint8,
         )
     )
+    phase_cosine_similarity: ProductInfo = field(
+        default_factory=lambda: ProductInfo(
+            name="phase_cosine_similarity",
+            long_name="Phase Cosine Similarity",
+            description=(
+                "Median cosine similarity of wrapped phase in each pixel's"
+                " neighborhood."
+            ),
+            fillvalue=np.nan,
+            attrs={"units": "unitless"},
+            # 8 bits (between 0 and 1) is around .001 precision
+            keep_bits=8,
+            dtype=np.float32,
+        )
+    )
 
     def __iter__(self):
         """Return all displacement dataset info as an iterable."""

--- a/src/disp_s1/product_info.py
+++ b/src/disp_s1/product_info.py
@@ -139,10 +139,10 @@ class DisplacementProducts:
             dtype=np.uint8,
         )
     )
-    phase_cosine_similarity: ProductInfo = field(
+    phase_similarity: ProductInfo = field(
         default_factory=lambda: ProductInfo(
-            name="phase_cosine_similarity",
-            long_name="Phase Cosine Similarity",
+            name="phase_similarity",
+            long_name="Phase Similarity",
             description=(
                 "Median cosine similarity of wrapped phase in each pixel's"
                 " neighborhood."


### PR DESCRIPTION
- The current recommended mask is 
```python
    bad_pixel_mask = is_water | bad_conncomp | (bad_temporal_coherence & bad_similarity)
    # Note: An alternate way to view this:
    # good_conncomp & is_no_water & (good_temporal_coherence | good_similarity)
```

- A more aggressive water mask is used on the browse images now. Still keeping a 1 km buffer for land water: I'm assuming lakes/rivers may change more significantly than ocean boundary