### PR TITLE
Fix reference picking for multi-burst input

### DIFF
--- a/src/disp_s1/pge_runconfig.py
+++ b/src/disp_s1/pge_runconfig.py
@@ -415,11 +415,11 @@ def _compute_reference_dates(
     # Mark any files beginning with "compressed" as compressed
     is_compressed = ["compressed" in str(Path(f).stem).lower() for f in cslc_file_list]
     # Get the dates of the base phase (works for either compressed, or regular cslc)
-    input_dates = [get_dates(f)[0].date() for f in cslc_file_list]
+    input_dates = sorted({get_dates(f)[0].date() for f in cslc_file_list})
 
     output_reference_idx: int = 0
     extra_reference_date: datetime.datetime | None = None
-    reference_dates = sorted([d.date() for d in reference_datetimes])
+    reference_dates = sorted({d.date() for d in reference_datetimes})
 
     for ref_date in reference_dates:
         # Find the nearest index that is greater than or equal to the reference date

--- a/tests/test_pge_runconfig.py
+++ b/tests/test_pge_runconfig.py
@@ -1,4 +1,5 @@
 import datetime
+import random
 import sys
 import warnings
 from pathlib import Path
@@ -233,8 +234,13 @@ def test_reference_date_computation():
         datetime.datetime(2020, 8, 21, 16, 13, 4),
         datetime.datetime(2020, 9, 2, 16, 13, 5),
     ]
-    # burst id/real name doesn't matter, just date and "compressed" or not
-    cslc_file_list = [f"{d.strftime('%Y%m%d.tif')}" for d in sensing_time_list]
+    # Doesn't have to be the real name
+    cslc_file_list = [
+        f"OPERA_T042-088905-{swath}_{d.strftime('%Y%m%dT%H%M%S')}.h5"
+        for d in sensing_time_list
+        for swath in ["IW1", "IW2", "IW3"]
+    ]
+    random.shuffle(cslc_file_list)
 
     # Assume we nominally will reset the reference each august
     reference_datetimes = [datetime.datetime(y, 8, 1) for y in range(2018, 2025)]
@@ -268,7 +274,13 @@ def test_reference_first_in_stack():
         datetime.datetime(2017, 3, 26, 0, 0),
         datetime.datetime(2017, 4, 7, 0, 0),
     ]
-    cslc_file_list = [f"{d.strftime('%Y%m%d.tif')}" for d in sensing_time_list]
+    cslc_file_list = [
+        f"OPERA_T042-088905-{swath}_{d.strftime('%Y%m%dT%H%M%S')}.h5"
+        for d in sensing_time_list
+        for swath in ["IW1", "IW2", "IW3"]
+    ]
+    random.shuffle(cslc_file_list)
+
     # Assume we nominally will reset the reference each august
     reference_datetimes = [datetime.datetime(y, 8, 1) for y in range(2018, 2025)]
     #   "11114": [


### PR DESCRIPTION
@mirzaees point out that the `input_dates` were duplicated for full frames:

```python
(Pdb) input_dates
[datetime.date(2016, 8, 10), datetime.date(2016, 8, 10), datetime.date(2016, 8, 10),  ....
```

This dedupes them before searching for the right index