### PR TITLE
Fix multiple reference date problem from repeated CompSLC dates

### DIFF
--- a/src/disp_s1/pge_runconfig.py
+++ b/src/disp_s1/pge_runconfig.py
@@ -418,10 +418,14 @@ def _get_first_after_selected(
 def _compute_reference_dates(
     reference_datetimes, cslc_file_list
 ) -> tuple[int, datetime.datetime | None]:
-    # Mark any files beginning with "compressed" as compressed
-    is_compressed = ["compressed" in str(Path(f).stem).lower() for f in cslc_file_list]
     # Get the dates of the base phase (works for either compressed, or regular cslc)
-    input_dates = sorted({get_dates(f)[0].date() for f in cslc_file_list})
+    # Use one burst ID as the template.
+    burst_to_file_list = group_by_burst(cslc_file_list)
+    burst_id = list(burst_to_file_list.keys())[0]
+    cur_files = sort_files_by_date(burst_to_file_list[burst_id])[0]
+    # Mark any files beginning with "compressed" as compressed
+    is_compressed = ["compressed" in str(Path(f).stem).lower() for f in cur_files]
+    input_dates = [get_dates(f)[0].date() for f in cur_files]
 
     output_reference_idx: int = 0
     extra_reference_date: datetime.datetime | None = None

--- a/tests/test_pge_runconfig.py
+++ b/tests/test_pge_runconfig.py
@@ -307,3 +307,35 @@ def test_reference_first_in_stack():
     )
     assert output_reference_idx == 0
     assert extra_reference_date is None
+
+
+def test_repeated_compressed_dates():
+    cslc_file_list = [
+        "compressed_t087_185680_iw1_20180722_20190412_20190705.h5",
+        "compressed_t087_185680_iw1_20190711_20190711_20191003.h5",
+        "compressed_t087_185680_iw1_20190711_20191009_20200107.h5",
+        "compressed_t087_185680_iw1_20190711_20200113_20200406.h5",
+        "compressed_t087_185680_iw1_20200717_20200412_20200729.h5",
+        "OPERA_L2_CSLC-S1_T087-185680-IW1_20200804T161629Z_20240501T010610Z_S1A_VV_v1.1.h5",
+        "OPERA_L2_CSLC-S1_T087-185680-IW1_20200810T161548Z_20240501T030849Z_S1B_VV_v1.1.h5",
+        "OPERA_L2_CSLC-S1_T087-185680-IW1_20200816T161630Z_20240501T042747Z_S1A_VV_v1.1.h5",
+        "OPERA_L2_CSLC-S1_T087-185680-IW1_20200822T161548Z_20240501T062744Z_S1B_VV_v1.1.h5",
+        "OPERA_L2_CSLC-S1_T087-185680-IW1_20200828T161631Z_20240501T075057Z_S1A_VV_v1.1.h5",
+        "OPERA_L2_CSLC-S1_T087-185680-IW1_20200903T161549Z_20240501T094950Z_S1B_VV_v1.1.h5",
+    ]
+    random.shuffle(cslc_file_list)
+
+    reference_datetimes = [
+        datetime.datetime(2017, 7, 9),
+        datetime.datetime(2018, 7, 16),
+        datetime.datetime(2019, 7, 11),
+        datetime.datetime(2020, 7, 17),
+        datetime.datetime(2021, 7, 12),
+    ]
+
+    output_reference_idx, extra_reference_date = pge_runconfig._compute_reference_dates(
+        reference_datetimes, cslc_file_list
+    )
+    # Should be the latest one: the compressed slc with 20200717
+    assert output_reference_idx == 4
+    assert extra_reference_date is None


### PR DESCRIPTION
See new test for situation leading to problem. Following @mirzaees 's idea to use one burst ID's file list instead.