### PR TITLE
Add step to combine previous amplitudes/amplitude dispersions for cleaner PS/SHP estimation

### DIFF
--- a/src/disp_s1/_masking.py
+++ b/src/disp_s1/_masking.py
@@ -150,6 +150,9 @@ def create_layover_shadow_masks(
         f = files[0]
         input_name = format_nc_filename(f, ds_name="/data/layover_shadow_mask")
         out_file = output_path / f"layover_shadow_{burst_id}.tif"
+        if out_file.exists():
+            output_files.append(out_file)
+            continue
 
         logger.info(f"Extracting layover shadow mask from {f} to {out_file}")
         layover_data = load_gdal(input_name)

--- a/src/disp_s1/_ps.py
+++ b/src/disp_s1/_ps.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from collections.abc import Sequence
+from pathlib import Path
+
+import dolphin.ps
+import numpy as np
+from dolphin import io, masking
+from dolphin._types import PathOrStr
+from dolphin.io import VRTStack
+from dolphin.workflows._utils import _create_burst_cfg, _remove_dir_if_empty
+from dolphin.workflows.config import DisplacementWorkflow
+from dolphin.workflows.wrapped_phase import _get_mask
+from opera_utils import group_by_burst
+
+logger = logging.getLogger(__name__)
+
+
+def precompute_ps(cfg: DisplacementWorkflow):
+    try:
+        grouped_slc_files = group_by_burst(cfg.cslc_file_list)
+    except ValueError as e:
+        # Make sure it's not some other ValueError
+        if "Could not parse burst id" not in str(e):
+            raise
+        # Otherwise, we have SLC files which are not OPERA burst files
+        grouped_slc_files = {"": cfg.cslc_file_list}
+
+    if cfg.amplitude_dispersion_files:
+        grouped_amp_dispersion_files = group_by_burst(cfg.amplitude_dispersion_files)
+    else:
+        grouped_amp_dispersion_files = defaultdict(list)
+    if cfg.amplitude_mean_files:
+        grouped_amp_mean_files = group_by_burst(cfg.amplitude_mean_files)
+    else:
+        grouped_amp_mean_files = defaultdict(list)
+
+    # ######################################
+    # 1. Burst-wise Wrapped phase estimation
+    # ######################################
+    if len(grouped_slc_files) > 1:
+        logger.info(f"Found SLC files from {len(grouped_slc_files)} bursts")
+        wrapped_phase_cfgs = [
+            (
+                burst,  # Include the burst for logging purposes
+                _create_burst_cfg(
+                    cfg,
+                    burst,
+                    grouped_slc_files,
+                    grouped_amp_mean_files,
+                    grouped_amp_dispersion_files,
+                ),
+            )
+            for burst in grouped_slc_files
+        ]
+        for _, burst_cfg in wrapped_phase_cfgs:
+            burst_cfg.create_dir_tree()
+        # Remove the mid-level directories which will be empty due to re-grouping
+        _remove_dir_if_empty(cfg.phase_linking._directory)
+        _remove_dir_if_empty(cfg.ps_options._directory)
+
+    else:
+        # grab the only key (either a burst, or "") and use that
+        cfg.create_dir_tree()
+        b = next(iter(grouped_slc_files.keys()))
+        wrapped_phase_cfgs = [(b, cfg)]
+
+
+def run_burst_ps(cfg: DisplacementWorkflow):
+    input_file_list = cfg.cslc_file_list
+    if not input_file_list:
+        msg = "No input files found"
+        raise ValueError(msg)
+
+    subdataset = cfg.input_options.subdataset
+    # Mark any files beginning with "compressed" as compressed
+    is_compressed = ["compressed" in str(f).lower() for f in input_file_list]
+
+    non_compressed_slcs = [
+        f for f, is_comp in zip(input_file_list, is_compressed) if not is_comp
+    ]
+    vrt_stack = VRTStack(
+        non_compressed_slcs,
+        subdataset=subdataset,
+        outfile=cfg.work_directory / "non_compressed_slc_stack.vrt",
+    )
+
+    layover_shadow_mask = (
+        cfg.layover_shadow_mask_files[0] if cfg.layover_shadow_mask_files else None
+    )
+    mask_filename = _get_mask(
+        output_dir=cfg.work_directory,
+        output_bounds=cfg.output_options.bounds,
+        output_bounds_wkt=cfg.output_options.bounds_wkt,
+        output_bounds_epsg=cfg.output_options.bounds_epsg,
+        like_filename=vrt_stack.outfile,
+        layover_shadow_mask=layover_shadow_mask,
+        cslc_file_list=non_compressed_slcs,
+    )
+    nodata_mask = masking.load_mask_as_numpy(mask_filename) if mask_filename else None
+
+    output_file_list = [
+        cfg.ps_options._output_file,
+        cfg.ps_options._amp_mean_file,
+        cfg.ps_options._amp_dispersion_file,
+    ]
+    ps_output = cfg.ps_options._output_file
+    if all(f.exists() for f in output_file_list):
+        logger.info(f"Skipping making existing PS files {output_file_list}")
+        return output_file_list
+
+    logger.info(f"Creating persistent scatterer file {ps_output}")
+    # dispersions: np.ndarray, means: np.ndarray, N: ArrayLike | Sequence
+    dolphin.ps.create_ps(
+        reader=vrt_stack,
+        output_file=output_file_list[0],
+        output_amp_mean_file=output_file_list[1],
+        output_amp_dispersion_file=output_file_list[2],
+        like_filename=vrt_stack.outfile,
+        amp_dispersion_threshold=cfg.ps_options.amp_dispersion_threshold,
+        nodata_mask=nodata_mask,
+        block_shape=cfg.worker_settings.block_shape,
+    )
+
+    compressed_slc_files = [
+        f for f, is_comp in zip(input_file_list, is_compressed) if is_comp
+    ]
+    logger.info(f"Combining existing means/dispersions from {compressed_slc_files}")
+    run_combine(
+        cfg.ps_options._amp_mean_file,
+        cfg.ps_options._amp_dispersion_file,
+        compressed_slc_files,
+        num_slc=len(non_compressed_slcs),
+        subdataset=subdataset,
+    )
+
+
+def run_combine(
+    cur_mean: Path,
+    cur_dispersion: Path,
+    compressed_slc_files: list[PathOrStr],
+    num_slc: int,
+    subdataset: str = "/data/VV",
+):
+    reader_compslc = io.HDF5StackReader.from_file_list(
+        file_list=compressed_slc_files,
+        dset_names=subdataset,
+        nodata=np.nan,
+    )
+    reader_compslc_dispersion = io.HDF5StackReader.from_file_list(
+        file_list=compressed_slc_files,
+        dset_names="/data/amplitude_dispersion",
+        nodata=np.nan,
+    )
+    reader_mean = io.RasterReader(cur_mean, band=1)
+    reader_dispersion = io.RasterReader(cur_dispersion, band=1)
+
+    # writer_mean = io.BackgroundRasterWriter(filename="combined_mean.tif")
+    # writer_dispersion = io.BackgroundRasterWriter(filename="combined_dispersions.tif")
+
+    def read_and_combine(
+        readers: Sequence[io.StackReader], rows: slice, cols: slice
+    ) -> tuple[np.ndarray, slice, slice]:
+        reader_compslc, reader_compslc_dispersion, reader_mean, reader_dispersion = (
+            readers
+        )
+        compslc_mean = np.abs(reader_compslc[:, rows, cols])
+        if compslc_mean.ndim == 2:
+            compslc_mean = compslc_mean[np.newaxis]
+        compslc_dispersion = reader_compslc_dispersion[:, rows, cols]
+        if compslc_dispersion.ndim == 2:
+            compslc_dispersion = compslc_dispersion[np.newaxis]
+
+        mean = reader_mean[rows, cols]
+        dispersion = reader_dispersion[rows, cols]
+
+        # Fit a line to each pixel with weighted least squares
+        dispersions = np.vstack([compslc_dispersion, dispersion])
+
+        means = np.vstack([compslc_mean, mean])
+        # Increase the weights from older to newer.
+        N = np.linspace(0, 1, num=len(means)) * num_slc
+        return (
+            dolphin.ps.combine_amplitude_dispersions(
+                dispersions=dispersions,
+                means=means,
+                N=N,
+            ),
+            rows,
+            cols,
+        )
+
+    out_paths = ["combined_dispersion.tif", "combined_mean.tif"]
+    readers = reader_compslc, reader_compslc_dispersion, reader_mean, reader_dispersion
+    writer = io.BackgroundStackWriter(out_paths, like_filename=cur_mean)
+    io.process_blocks(
+        readers=readers,
+        writer=writer,
+        func=read_and_combine,
+        block_shape=(512, 512),
+    )
+
+    writer.notify_finished()
+    return out_paths

--- a/src/disp_s1/_ps.py
+++ b/src/disp_s1/_ps.py
@@ -257,7 +257,7 @@ def run_combine(
         readers=readers,
         writer=writer,
         func=read_and_combine,
-        block_shape=(512, 512),
+        block_shape=(256, 256),
         num_threads=1,
     )
 

--- a/src/disp_s1/main.py
+++ b/src/disp_s1/main.py
@@ -71,7 +71,7 @@ def run(
     # If we are passed Compressed SLCs, combine the old amplitudes with the
     # current real SLCs for a better estimate of amplitude dispersion for PS/SHPs
     if any("compressed" in f.name.lower() for f in cfg.cslc_file_list):
-        logger.info("Combining old amplitudes with current SLCs:")
+        logger.info("Combining old amplitudes with current SLCs")
         combined_dispersion_files, combined_mean_files = precompute_ps(cfg=cfg)
         cfg.amplitude_dispersion_files = combined_dispersion_files
         cfg.amplitude_mean_files = combined_mean_files

--- a/src/disp_s1/main.py
+++ b/src/disp_s1/main.py
@@ -68,13 +68,17 @@ def run(
         )
         cfg.layover_shadow_mask_files = layover_binary_mask_files
 
-    # If we are passed Compressed SLCs, combine the old amplitudes with the
-    # current real SLCs for a better estimate of amplitude dispersion for PS/SHPs
     if any("compressed" in f.name.lower() for f in cfg.cslc_file_list):
+        # If we are passed Compressed SLCs, combine the old amplitudes with the
+        # current real SLCs for a better estimate of amplitude dispersion for PS/SHPs
         logger.info("Combining old amplitudes with current SLCs")
         combined_dispersion_files, combined_mean_files = precompute_ps(cfg=cfg)
         cfg.amplitude_dispersion_files = combined_dispersion_files
         cfg.amplitude_mean_files = combined_mean_files
+    else:
+        # This is the first ministack: The amplitude estimation will be weak.
+        # Drop the PS threshold to a conservate number to avoid false positives
+        cfg.ps_options.amp_dispersion_threshold = 0.15
 
     # Run dolphin's displacement workflow
     out_paths = run_displacement(cfg=cfg, debug=debug)


### PR DESCRIPTION
Closes #78  

Tested by running once on 10 dates, 2 bursts:
- Run with all 10 dates
- Then run with the first 5, pass the compressed SLC, run with 1+second 5

Comparing the amplitude dispersion for the stack of 10 (left) and the "combined_dispersion.tif" (middle), the results are the same except at layover/shadow regions.
<img width="1002" alt="image" src="https://github.com/user-attachments/assets/fe702e06-d205-4ccc-af25-f613d89444c3">


Another comparison: the amplitude dispersion from using only 5 dates (left) with the combined (middle). The whole area has higher amplitude dispersion from incorporating more data, leading to fewer false positive PS
<img width="965" alt="image" src="https://github.com/user-attachments/assets/ed9d9688-aa48-4c2d-b16e-019dcab52ca6">


We're also adding one special case to lower the amplitude dispersion threshold to pick PS for just the first ministack, before we're passed any compressed SLCs. one ministack is too noisy to have a typicl 0.25-ish threshold.