### PR TITLE
Only create one water masking during processing

### DIFF
--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -259,7 +259,7 @@ def create_output_product(
     bad_pixel_mask = is_water | bad_conncomp | (bad_temporal_coherence & bad_similarity)
     # Note: An alternate way to view this:
     # good_conncomp & is_no_water & (good_temporal_coherence | good_similarity)
-    recommended_mask = ~bad_pixel_mask
+    recommended_mask = np.logical_not(bad_pixel_mask)
     del temporal_coherence, conncomps, similarity
 
     filtered_disp_arr = filtering.filter_long_wavelength(
@@ -339,6 +339,7 @@ def create_output_product(
             ps_mask_filename,
             shp_count_filename,
             unwrapper_mask_filename,
+            water_mask_filename,
             similarity_filename,
         ]
 

--- a/src/disp_s1/product_info.py
+++ b/src/disp_s1/product_info.py
@@ -139,6 +139,16 @@ class DisplacementProducts:
             dtype=np.uint8,
         )
     )
+    water_mask: ProductInfo = field(
+        default_factory=lambda: ProductInfo(
+            name="water_mask",
+            long_name="Water Mask",
+            description="Binary mask created to ignore water during processing.",
+            fillvalue=255,
+            attrs={"units": "unitless"},
+            dtype=np.uint8,
+        )
+    )
     phase_similarity: ProductInfo = field(
         default_factory=lambda: ProductInfo(
             name="phase_similarity",


### PR DESCRIPTION
Remove the conservative/aggressive versions in favor of one with a 1km buffer from the water distance file.

Save the result in the product for easier QA