### PR TITLE
Fix similarity array loading using `filled(0)`

### DIFF
--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -251,7 +251,7 @@ def create_output_product(
         is_water = np.zeros(temporal_coherence.shape, dtype=bool)
 
     conncomps = io.load_gdal(conncomp_filename, masked=True).filled(0)
-    similarity = io.load_gdal(similarity_filename, masked=True).mean()
+    similarity = io.load_gdal(similarity_filename, masked=True).filled(0)
 
     # Mark pixels that are bad
     is_zero_conncomp = conncomps == 0


### PR DESCRIPTION
`.mean()` should not have been called on this loading of similarity; as a result, lower quality areas will have all `True` for `bad_similarity`, and hence all 0 `recommended_mask`.