### PR TITLE
Separate the netcdf creation function in `main`

### DIFF
--- a/src/disp_s1/product_info.py
+++ b/src/disp_s1/product_info.py
@@ -172,7 +172,7 @@ class DisplacementProducts:
     @property
     def names(self) -> list[str]:
         """Return all displacement dataset names as a list."""
-        return list(self.__dict__.keys())
+        return [v.name for v in self.__dict__.values()]
 
 
 # Create a single instance to be used throughout the application


### PR DESCRIPTION
Can be used to make it easier to run just the creation portion (e.g. on the separate outputs of `dolphin`)