### PR TITLE
Add more CEOS metadata items

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,6 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --show-fixes]
-      - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.13.0"
@@ -35,3 +34,10 @@ repos:
         - types-setuptools
         - types-requests
         - "pydantic>=2.4"
+
+
+  - repo: https://github.com/psf/black
+    rev: "24.10.0"
+    hooks:
+      - id: black
+        args: [--preview]

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -753,7 +753,7 @@ def _create_identification_group(
             group=identification_group,
             name="source_data_range_resolutions",
             dimensions=(),
-            data=[2.7, 3.1, 3.5],
+            data="[2.7, 3.1, 3.5]",
             fillvalue=None,
             description=(
                 "List of [IW1, IW2, IW3] range resolutions from source L1 Sentinel-1"
@@ -765,7 +765,7 @@ def _create_identification_group(
             group=identification_group,
             name="source_data_azimuth_resolutions",
             dimensions=(),
-            data=[22.5, 22.7, 22.6],
+            data="[22.5, 22.7, 22.6]",
             fillvalue=None,
             description=(
                 "List of [IW1, IW2, IW3] azimuth resolutions from L1 Sentinel-1 SLCs"

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -665,6 +665,17 @@ def _create_identification_group(
             description="Mean value of valid pixels within temporal_coherence layer.",
             attrs={"units": "unitless"},
         )
+        # CEOS: Section 1.3
+        _create_dataset(
+            group=identification_group,
+            name="ceos_analysis_ready_data_product_type",
+            dimensions=(),
+            data="InSAR",
+            fillvalue=None,
+            description="CEOS Analysis Ready Data (CARD) product type name",
+            attrs={"units": "unitless"},
+        )
+        # CEOS: Section 1.4
         _create_dataset(
             group=identification_group,
             name="ceos_analysis_ready_data_document_identifier",
@@ -674,10 +685,32 @@ def _create_identification_group(
             description="CEOS Analysis Ready Data (CARD) document identifier",
             attrs={"units": "unitless"},
         )
+        # CEOS: Section 1.6.4 source acquisition parameters
+        _create_dataset(
+            group=identification_group,
+            name="source_data_polarization",
+            dimensions=(),
+            data="VV",
+            fillvalue=None,
+            description="Radar polarization of input products",
+            attrs={"units": "unitless"},
+        )
         # CEOS: Section 1.6.7 source data attributes
         _create_dataset(
             group=identification_group,
             name="source_data_access",
+            dimensions=(),
+            data="https://search.asf.alaska.edu/#/?dataset=OPERA-S1&productTypes=CSLC",
+            fillvalue=None,
+            description=(
+                "The metadata identifies the location from where the source data can be"
+                " retrieved, expressed as a URL or DOI."
+            ),
+            attrs={"units": "unitless"},
+        )
+        _create_dataset(
+            group=identification_group,
+            name="source_data_file_list",
             dimensions=(),
             data=",".join(
                 p.stem for p in pge_runconfig.input_file_group.cslc_file_list
@@ -1152,6 +1185,7 @@ def copy_cslc_metadata_to_compressed(
         "/metadata/orbit",  #          Group
         "/metadata/processing_information/input_burst_metadata/wavelength",
         "/metadata/processing_information/input_burst_metadata/platform_id",
+        "/metadata/processing_information/input_burst_metadata/radar_center_frequency",
         "/identification/zero_doppler_end_time",
         "/identification/zero_doppler_start_time",
         "/identification/bounding_polygon",
@@ -1198,6 +1232,8 @@ def copy_cslc_metadata_to_displacement(
         "/identification/orbit_pass_direction",
         "/identification/absolute_orbit_number",
         "/metadata/processing_information/input_burst_metadata/platform_id",
+        "/metadata/processing_information/input_burst_metadata/wavelength",
+        "/metadata/processing_information/input_burst_metadata/radar_center_frequency",
     ]
     _copy_hdf5_dsets(
         source_file=reference_cslc_file,

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -751,25 +751,34 @@ def _create_identification_group(
         )
         _create_dataset(
             group=identification_group,
-            name="source_data_range_resolution",
+            name="source_data_range_resolutions",
             dimensions=(),
             data=[2.7, 3.1, 3.5],
             fillvalue=None,
             description=(
-                "List of [IW1, IW2, IW3] range resolutions from source Sentinel-1 SLCs"
+                "List of [IW1, IW2, IW3] range resolutions from source L1 Sentinel-1"
+                " SLCs"
             ),
             attrs={"units": "meters"},
         )
         _create_dataset(
             group=identification_group,
-            name="source_data_azimuth_spacing",
+            name="source_data_azimuth_resolutions",
             dimensions=(),
             data=[22.5, 22.7, 22.6],
             fillvalue=None,
             description=(
-                "List of [IW1, IW2, IW3] azimuth resolutions from source Sentinel-1"
-                " SLCs"
+                "List of [IW1, IW2, IW3] azimuth resolutions from L1 Sentinel-1 SLCs"
             ),
+            attrs={"units": "meters"},
+        )
+        _create_dataset(
+            group=identification_group,
+            name="source_data_x_spacing",
+            dimensions=(),
+            data=5,
+            fillvalue=None,
+            description="Pixel spacing of source geocoded SLC data in the x-direction.",
             attrs={"units": "meters"},
         )
         _create_dataset(

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -670,7 +670,7 @@ def _create_identification_group(
             group=identification_group,
             name="ceos_analysis_ready_data_product_type",
             dimensions=(),
-            data="Displacement",
+            data="InSAR",
             fillvalue=None,
             description="CEOS Analysis Ready Data (CARD) product type name",
             attrs={"units": "unitless"},

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -716,6 +716,15 @@ def _create_identification_group(
         # CEOS: Section 1.6.7 source data attributes
         _create_dataset(
             group=identification_group,
+            name="source_data_original_institution",
+            dimensions=(),
+            data="European Space Agency",
+            fillvalue=None,
+            description="Original processing institution of Sentinel-1 SLC data",
+            attrs={"units": "unitless"},
+        )
+        _create_dataset(
+            group=identification_group,
             name="source_data_access",
             dimensions=(),
             data="https://search.asf.alaska.edu/#/?dataset=OPERA-S1&productTypes=CSLC",
@@ -742,11 +751,25 @@ def _create_identification_group(
         )
         _create_dataset(
             group=identification_group,
-            name="source_data_x_spacing",
+            name="source_data_range_resolution",
             dimensions=(),
-            data=5,
+            data=[2.7, 3.1, 3.5],
             fillvalue=None,
-            description="Pixel spacing of source geocoded SLC data in the x-direction.",
+            description=(
+                "List of [IW1, IW2, IW3] range resolutions from source Sentinel-1 SLCs"
+            ),
+            attrs={"units": "meters"},
+        )
+        _create_dataset(
+            group=identification_group,
+            name="source_data_azimuth_spacing",
+            dimensions=(),
+            data=[22.5, 22.7, 22.6],
+            fillvalue=None,
+            description=(
+                "List of [IW1, IW2, IW3] azimuth resolutions from source Sentinel-1"
+                " SLCs"
+            ),
             attrs={"units": "meters"},
         )
         _create_dataset(
@@ -757,6 +780,18 @@ def _create_identification_group(
             fillvalue=None,
             description="Pixel spacing of source geocoded SLC data in the y-direction.",
             attrs={"units": "meters"},
+        )
+        # Source for the max. NESZ:
+        # (https://sentinels.copernicus.eu/web/sentinel/user-guides/
+        # 1.6.9
+        _create_dataset(
+            group=identification_group,
+            name="source_data_max_noise_equivalent_sigma_zero",
+            dimensions=(),
+            data=-22.0,
+            fillvalue=None,
+            description="Maximum Noise equivalent sigma0 in dB",
+            attrs={"units": "dB"},
         )
         _create_dataset(
             group=identification_group,
@@ -1204,6 +1239,10 @@ def copy_cslc_metadata_to_compressed(
         "/metadata/processing_information/input_burst_metadata/wavelength",
         "/metadata/processing_information/input_burst_metadata/platform_id",
         "/metadata/processing_information/input_burst_metadata/radar_center_frequency",
+        "/metadata/processing_information/input_burst_metadata/ipf_version",
+        "/metadata/processing_information/algorithms/COMPASS_version",
+        "/metadata/processing_information/algorithms/ISCE3_version",
+        "/metadata/processing_information/algorithms/s1_reader_version",
         "/identification/zero_doppler_end_time",
         "/identification/zero_doppler_start_time",
         "/identification/bounding_polygon",
@@ -1252,6 +1291,9 @@ def copy_cslc_metadata_to_displacement(
         "/metadata/processing_information/input_burst_metadata/platform_id",
         "/metadata/processing_information/input_burst_metadata/wavelength",
         "/metadata/processing_information/input_burst_metadata/radar_center_frequency",
+        "/metadata/processing_information/algorithms/COMPASS_version",
+        "/metadata/processing_information/algorithms/ISCE3_version",
+        "/metadata/processing_information/algorithms/s1_reader_version",
     ]
     _copy_hdf5_dsets(
         source_file=reference_cslc_file,

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -688,6 +688,24 @@ def _create_identification_group(
         # CEOS: Section 1.6.4 source acquisition parameters
         _create_dataset(
             group=identification_group,
+            name="acquisition_mode",
+            dimensions=(),
+            data="IW",
+            fillvalue=None,
+            description="Radar acquisition mode for input products",
+            attrs={"units": "unitless"},
+        )
+        _create_dataset(
+            group=identification_group,
+            name="radar_center_frequency",
+            dimensions=(),
+            data=5405000454.33435,
+            fillvalue=None,
+            description="Radar center frequency of input products",
+            attrs={"units": "Hertz"},
+        )
+        _create_dataset(
+            group=identification_group,
             name="source_data_polarization",
             dimensions=(),
             data="VV",

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -670,7 +670,7 @@ def _create_identification_group(
             group=identification_group,
             name="ceos_analysis_ready_data_product_type",
             dimensions=(),
-            data="InSAR",
+            data="Displacement",
             fillvalue=None,
             description="CEOS Analysis Ready Data (CARD) product type name",
             attrs={"units": "unitless"},


### PR DESCRIPTION
Within `/identification`, added:
1. "ceos_analysis_ready_data_product_type" dataset with value "Displacement"
2. "acquisition_mode" dataset with value "IW"
3. "radar_center_frequency" dataset
4. "source_data_polarization" dataset with value "VV"
5. "source_data_original_institution" dataset with value "European Space Agency"
6. "source_data_access" dataset with a URL for OPERA-S1 CSLC data
7. "source_data_file_list" dataset (replacing "source_data_access")
8. "source_data_range_resolutions" dataset with resolutions for IW1, IW2, and IW3
9. "source_data_azimuth_resolutions" dataset with resolutions for IW1, IW2, and IW3
10. "source_data_max_noise_equivalent_sigma_zero" dataset, copied from RTC



In the `copy_cslc_metadata_to_compressed` and `copy_cslc_metadata_to_displacement` functions, added new metadata fields to be copied, including:
   - radar_center_frequency
   - ipf_version
   - COMPASS_version
   - ISCE3_version
   - s1_reader_version