### PR TITLE
Fix spurt conncomp generation during reference changeover

### DIFF
--- a/configs/algorithm_parameters_historical.yaml
+++ b/configs/algorithm_parameters_historical.yaml
@@ -1,7 +1,7 @@
 # JSON file containing frame-specific algorithm parameters to override the defaults passed
 #   in the `algorithm_parameters.yaml`.
 #   Type: string | null.
-algorithm_parameters_overrides_json: opera-disp-s1-algorithm-parameters-overrides-2024-11-26.json
+algorithm_parameters_overrides_json: opera-disp-s1-algorithm-parameters-overrides-2024-12-23.json
 ps_options:
   # Amplitude dispersion threshold to consider a pixel a PS.
   #   Type: number.

--- a/src/disp_s1/_utils.py
+++ b/src/disp_s1/_utils.py
@@ -53,8 +53,8 @@ def _update_snaphu_conncomps(
 
     """
     args_list = [
-        (unw_f, cor_f, nlooks, mask_filename, unwrap_options)
-        for unw_f, cor_f in zip(timeseries_paths, stitched_cor_paths)
+        (idx, unw_f, cor_f, nlooks, mask_filename, unwrap_options)
+        for idx, (unw_f, cor_f) in enumerate(zip(timeseries_paths, stitched_cor_paths))
     ]
 
     mp_context = get_context("spawn")
@@ -96,6 +96,19 @@ def _update_spurt_conncomps(
             pass
         new_conncomp_paths.append(new_name)
     return new_conncomp_paths
+
+
+def _regrow(args: tuple[int, Path, Path, int, PathOrStr, UnwrapOptions]) -> Path:
+    scratch_idx, unw_f, cor_f, nlooks, mask_filename, unwrap_options = args
+    new_path = grow_conncomp_snaphu(
+        unw_filename=unw_f,
+        corr_filename=cor_f,
+        nlooks=nlooks,
+        mask_filename=mask_filename,
+        cost=unwrap_options.snaphu_options.cost,
+        scratchdir=unwrap_options._directory / f"scratch{scratch_idx}",
+    )
+    return new_path
 
 
 def _create_correlation_images(
@@ -140,16 +153,3 @@ def _create_correlation_images(
     )
 
     return output_paths
-
-
-def _regrow(args: tuple[Path, Path, int, PathOrStr, UnwrapOptions]) -> Path:
-    unw_f, cor_f, nlooks, mask_filename, unwrap_options = args
-    new_path = grow_conncomp_snaphu(
-        unw_filename=unw_f,
-        corr_filename=cor_f,
-        nlooks=nlooks,
-        mask_filename=mask_filename,
-        cost=unwrap_options.snaphu_options.cost,
-        scratchdir=unwrap_options._directory / "scratch2",
-    )
-    return new_path

--- a/src/disp_s1/main.py
+++ b/src/disp_s1/main.py
@@ -207,7 +207,7 @@ def create_products(
         elif method == "spurt":
             out_paths.conncomp_paths = _update_spurt_conncomps(
                 timeseries_paths=out_paths.timeseries_paths,
-                conncomp_paths=out_paths.conncomp_paths,
+                template_conncomp_path=out_paths.conncomp_paths[0],
             )
         else:
             raise NotImplementedError(

--- a/tests/data/opera-disp-s1-algorithm-parameters-overrides-2024-11-26.json
+++ b/tests/data/opera-disp-s1-algorithm-parameters-overrides-2024-11-26.json
@@ -1,1 +1,0 @@
-../../configs/opera-disp-s1-algorithm-parameters-overrides-2024-11-26.json

--- a/tests/data/opera-disp-s1-algorithm-parameters-overrides-2024-12-23.json
+++ b/tests/data/opera-disp-s1-algorithm-parameters-overrides-2024-12-23.json
@@ -1,0 +1,1 @@
+../../configs/opera-disp-s1-algorithm-parameters-overrides-2024-12-23.json

--- a/tests/test_pge_runconfig.py
+++ b/tests/test_pge_runconfig.py
@@ -355,8 +355,6 @@ def test_algorithm_overrides(overrides_file, algorithm_parameters_file):
 
     p2 = pge_runconfig._override_parameters(orig_params, 23210)  # hawaii
     assert p2.unwrap_options.unwrap_method == "spurt"
-    p3 = pge_runconfig._override_parameters(orig_params, 18903)  # ridgecrest
-    assert p3.unwrap_options.unwrap_method == "phass"
     p4 = pge_runconfig._override_parameters(
         orig_params, 1234
     )  # frame id with no override

--- a/tests/test_pge_runconfig.py
+++ b/tests/test_pge_runconfig.py
@@ -345,7 +345,7 @@ def test_repeated_compressed_dates():
 def overrides_file():
     return (
         Path(__file__).parent
-        / "data/opera-disp-s1-algorithm-parameters-overrides-2024-11-26.json"
+        / "data/opera-disp-s1-algorithm-parameters-overrides-2024-12-23.json"
     )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -105,9 +105,9 @@ def setup_test_files(tmp_path):
         "20170709_20171130",
     ]
     ts_paths = []
+    # Create empty test files for timeseries outputs
     for date in ts_dates:
         path = ts_dir / f"{date}.tif"
-        # Create empty test files
         np.zeros((1, 1)).tofile(path)
         ts_paths.append(path)
 
@@ -124,10 +124,10 @@ def setup_test_files(tmp_path):
         "20170615_20170721",
         "20170627_20170709",
     ]
+    # Create empty test files for conncomps created during unwrapping
     cc_paths = []
     for date in cc_dates:
         path = unwrap_dir / f"{date}.unw.conncomp.tif"
-        # Create empty test files
         np.zeros((1, 1)).tofile(path)
         cc_paths.append(path)
 
@@ -135,13 +135,10 @@ def setup_test_files(tmp_path):
 
 
 def test_update_spurt_conncomps(setup_test_files):
-    """Test the _update_spurt_conncomps function."""
     ts_paths, cc_paths = setup_test_files
 
-    # Run the function
     updated_paths = _update_spurt_conncomps(ts_paths, cc_paths[0])
 
-    # Test 1: Check that output length matches input timeseries length
     assert len(updated_paths) == len(
         ts_paths
     ), "Output length should match timeseries length"
@@ -152,11 +149,8 @@ def test_update_spurt_conncomps(setup_test_files):
         exist_status
     ), f"Missing files at indices: {[i for i, x in enumerate(exist_status) if not x]}"
 
-    # Test 3: Check that output paths match timeseries date patterns
+    # Check that output paths match timeseries date patterns
     for ts_p, cc_p in zip(ts_paths, updated_paths):
         ts_stem = ts_p.stem  # e.g. "20160708_20170603"
         assert cc_p.stem.startswith(ts_stem)
-
-    # Test 4: Check correct extensions on output files
-    for p in updated_paths:
-        assert p.name.endswith(".unw.conncomp.tif"), f"Wrong extension for {p}"
+        assert cc_p.name.endswith(".unw.conncomp.tif"), f"Wrong extension for {cc_p}"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,11 @@ from dolphin import io
 from dolphin.constants import SENTINEL_1_WAVELENGTH
 from dolphin.workflows import UnwrapOptions
 
-from disp_s1._utils import _create_correlation_images, _update_snaphu_conncomps
+from disp_s1._utils import (
+    _create_correlation_images,
+    _update_snaphu_conncomps,
+    _update_spurt_conncomps,
+)
 
 DATA_DIR = Path(__file__).parent / "data"
 UNW_FILE = DATA_DIR / "20160716_20160809.unw.tif"
@@ -71,3 +75,88 @@ def test_update_snaphu_conncomps(ts_filenames):
         unwrap_options=UnwrapOptions(),
         nlooks=50,
     )
+
+
+@pytest.fixture
+def setup_test_files(tmp_path):
+    """Create temporary test files mimicking the timeseries and conncomp structure."""
+    # Create directories
+    unwrap_dir = tmp_path / "unwrapped"
+    ts_dir = tmp_path / "timeseries"
+    unwrap_dir.mkdir()
+    ts_dir.mkdir()
+
+    # Create timeseries paths (these are the target names we want)
+    ts_dates = [
+        "20160708_20170603",
+        "20160708_20170615",
+        "20160708_20170627",
+        "20160708_20170709",
+        "20170709_20170721",
+        "20170709_20170814",
+        "20170709_20170826",
+        "20170709_20170907",
+        "20170709_20170919",
+        "20170709_20171001",
+        "20170709_20171013",
+        "20170709_20171025",
+        "20170709_20171106",
+        "20170709_20171118",
+        "20170709_20171130",
+    ]
+    ts_paths = []
+    for date in ts_dates:
+        path = ts_dir / f"{date}.tif"
+        # Create empty test files
+        np.zeros((1, 1)).tofile(path)
+        ts_paths.append(path)
+
+    # Create some conncomp files (including the ones that caused issues)
+    cc_dates = [
+        "20160708_20170603",
+        "20160708_20170615",
+        "20160708_20170627",
+        "20170603_20170615",
+        "20170603_20170627",
+        "20170603_20170709",
+        "20170615_20170627",
+        "20170615_20170709",
+        "20170615_20170721",
+        "20170627_20170709",
+    ]
+    cc_paths = []
+    for date in cc_dates:
+        path = unwrap_dir / f"{date}.unw.conncomp.tif"
+        # Create empty test files
+        np.zeros((1, 1)).tofile(path)
+        cc_paths.append(path)
+
+    return ts_paths, cc_paths
+
+
+def test_update_spurt_conncomps(setup_test_files):
+    """Test the _update_spurt_conncomps function."""
+    ts_paths, cc_paths = setup_test_files
+
+    # Run the function
+    updated_paths = _update_spurt_conncomps(ts_paths, cc_paths[0])
+
+    # Test 1: Check that output length matches input timeseries length
+    assert len(updated_paths) == len(
+        ts_paths
+    ), "Output length should match timeseries length"
+
+    # Test 2: Verify all output paths exist
+    exist_status = [p.exists() for p in updated_paths]
+    assert all(
+        exist_status
+    ), f"Missing files at indices: {[i for i, x in enumerate(exist_status) if not x]}"
+
+    # Test 3: Check that output paths match timeseries date patterns
+    for ts_p, cc_p in zip(ts_paths, updated_paths):
+        ts_stem = ts_p.stem  # e.g. "20160708_20170603"
+        assert cc_p.stem.startswith(ts_stem)
+
+    # Test 4: Check correct extensions on output files
+    for p in updated_paths:
+        assert p.name.endswith(".unw.conncomp.tif"), f"Wrong extension for {p}"


### PR DESCRIPTION
Addresses error found by Phil during system tests:
```
RuntimeError: /home/mamba/scratch_dir/unwrapped/20180713_20180719.unw.conncomp.tif: No such file or directory
```