### PR TITLE
Change `static_layers_data_access` URL to hardcoded ASF link

### DIFF
--- a/src/disp_s1/pge_runconfig.py
+++ b/src/disp_s1/pge_runconfig.py
@@ -163,12 +163,6 @@ class ProductPathGroup(YamlModel):
             " the standard product output."
         ),
     )
-    static_layers_data_access: str = Field(
-        "(Not provided)",
-        description=(
-            "Location of the static layers product associated with this product"
-        ),
-    )
     model_config = ConfigDict(extra="forbid")
 
 

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -51,7 +51,7 @@ GLOBAL_ATTRS = {
     "contact": "opera-sds-ops@jpl.nasa.gov",
     "institution": "NASA JPL",
     "mission_name": "OPERA",
-    "reference_document": "JPL D–108765",
+    "reference_document": "JPL D-108765",
     "title": "OPERA_L3_DISP-S1 Product",
 }
 
@@ -568,11 +568,13 @@ def _create_identification_group(
             group=identification_group,
             name="static_layers_data_access",
             dimensions=(),
-            data=pge_runconfig.product_path_group.static_layers_data_access,
+            data=(
+                "https://search.asf.alaska.edu/#/?dataset=OPERA-S1&productTypes=DISP-S1"
+            ),
             fillvalue=None,
             description=(
-                "Location of the static layers product associated with this product"
-                " (URL or DOI)"
+                "URL of the static layers product associated with this Displacement"
+                " product"
             ),
         )
         _create_dataset(


### PR DESCRIPTION
- Using the default search url for the static layers metadata
- even if the ASF mechanism is there to link to a frame-specific url, @collinss-jpl should not need to pass something into us since we already have the frame id