### PR TITLE
Add timeseries residuals to product

### DIFF
--- a/.github/workflows/test-build-push.yml
+++ b/.github/workflows/test-build-push.yml
@@ -19,7 +19,7 @@ jobs:
           - label: Latest
             tag: "main"
           - label: Last Release
-            tag: v0.28.0
+            tag: v0.35.0
 
       fail-fast: true
     name: ${{ matrix.os }} • ${{ matrix.dolphin.label }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,13 +21,13 @@ repos:
 
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.4
+    rev: v0.8.6
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --show-fixes]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.14.0"
+    rev: "v1.14.1"
     hooks:
       - id: mypy
         additional_dependencies:

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -25,7 +25,7 @@ dependencies:
   - cxx-compiler # for whirlwind
   # # Spurt is not yet on pip/conda, but only has one extra (...which also is badly supported on conda-forge)
   # - ortools==9.8.3296
-  - dolphin>=0.30.0
+  - dolphin>=0.35.0
   - pip
     # - dolphin==0.31.1
     # - git+https://github.com/isce-framework/spurt@30562d4e883e93d11e5d3fb4fcdf953214875591

--- a/src/disp_s1/main.py
+++ b/src/disp_s1/main.py
@@ -480,6 +480,9 @@ def create_displacement_products(
     iono_files = out_paths.ionospheric_corrections or [None] * len(
         out_paths.timeseries_paths
     )
+    residual_files = out_paths.timeseries_paths or [None] * len(
+        out_paths.timeseries_paths
+    )
 
     files = [
         ProductFiles(
@@ -498,7 +501,7 @@ def create_displacement_products(
             out_paths.timeseries_paths,
             out_paths.conncomp_paths,
             out_paths.stitched_cor_paths,
-            out_paths.timeseries_residual_paths,
+            residual_files,
             iono_files,
         )
     ]

--- a/src/disp_s1/main.py
+++ b/src/disp_s1/main.py
@@ -334,6 +334,7 @@ class ProductFiles(NamedTuple):
     ps_mask: Path
     ionosphere: Path | None
     similarity: Path
+    residual: Path
     water_mask: Path | None
 
 
@@ -412,6 +413,7 @@ def process_product(
         ps_mask_filename=files.ps_mask,
         shp_count_filename=files.shp_counts,
         similarity_filename=files.similarity,
+        timeseries_residual_filename=files.residual,
         water_mask_filename=files.water_mask,
         los_east_file=los_east_file,
         los_north_file=los_north_file,
@@ -489,12 +491,14 @@ def create_displacement_products(
             shp_counts=out_paths.stitched_shp_count_file,
             ionosphere=iono,
             similarity=out_paths.stitched_similarity_file,
+            residual=resid,
             water_mask=water_mask,
         )
-        for unw, cc, cor, iono in zip(
+        for unw, cc, cor, resid, iono in zip(
             out_paths.timeseries_paths,
             out_paths.conncomp_paths,
             out_paths.stitched_cor_paths,
+            out_paths.timeseries_residual_paths,
             iono_files,
         )
     ]

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -86,6 +86,7 @@ def create_output_product(
     ps_mask_filename: Filename,
     shp_count_filename: Filename,
     similarity_filename: Filename,
+    timeseries_residual_filename: Filename,
     water_mask_filename: Filename | None,
     pge_runconfig: RunConfig,
     dolphin_config: DisplacementWorkflow,
@@ -117,6 +118,8 @@ def create_output_product(
         The path to statistically homogeneous pixels (SHP) counts.
     similarity_filename : Filename
         The path to the cosine similarity image.
+    timeseries_residual_filename : Filename
+        The path to the timeseries inversion residual sum image.
     water_mask_filename : Filename, optional
         Path to the binary water mask to use in creating a recommended mask.
     pge_runconfig : Optional[RunConfig], optional
@@ -345,6 +348,7 @@ def create_output_product(
             shp_count_filename,
             water_mask_filename,
             similarity_filename,
+            timeseries_residual_filename,
         ]
 
         for info, filename in zip(product_infos[3:], data_files, strict=True):

--- a/src/disp_s1/product_info.py
+++ b/src/disp_s1/product_info.py
@@ -154,6 +154,20 @@ class DisplacementProducts:
             dtype=np.float32,
         )
     )
+    timeseries_inversion_residuals: ProductInfo = field(
+        default_factory=lambda: ProductInfo(
+            name="timeseries_inversion_residuals",
+            long_name="Timeseries inversion residuals",
+            description=(
+                "Sum of residuals of the timeseries inversion for this secondary date."
+            ),
+            fillvalue=np.nan,
+            attrs={"units": "radians"},
+            # 8 bits (between 0 and 1) is around .001 precision
+            keep_bits=7,
+            dtype=np.float32,
+        )
+    )
 
     def __iter__(self):
         """Return all displacement dataset info as an iterable."""


### PR DESCRIPTION
Changed the copy metadata function to receive tuples of paths: `(source path, dest path)`. If `dest path` is None, if copies to the same location (as is done for the compressed SLCs to make them match).