### PR TITLE
Adapt PCM ionosphere download script, add `disp-s1 download` for `ionosphere` and `static-layers`

### DIFF
--- a/.github/workflows/test-build-push.yml
+++ b/.github/workflows/test-build-push.yml
@@ -41,7 +41,7 @@ jobs:
               - conda-forge
       - name: Install
         run: |
-          python -m pip install "opera-utils>=0.11.0" git+https://github.com/isce-framework/dolphin@${{ matrix.dolphin.tag }}
+          python -m pip install "opera-utils>=0.14.0" asf_search git+https://github.com/isce-framework/dolphin@${{ matrix.dolphin.tag }}
           pip install --no-deps .
       - name: Install test dependencies
         run: |

--- a/src/disp_s1/cli/__init__.py
+++ b/src/disp_s1/cli/__init__.py
@@ -1,6 +1,6 @@
 import click
 
-from .download import download_ionosphere
+from .download import download_group
 from .make_browse import make_browse
 from .run import run_cli
 from .validate import validate
@@ -20,7 +20,7 @@ def cli_app(ctx: click.Context, debug: bool) -> None:
 cli_app.add_command(run_cli)
 cli_app.add_command(validate)
 cli_app.add_command(make_browse)
-cli_app.add_command(download_ionosphere)
+cli_app.add_command(download_group)
 
 if __name__ == "__main__":
     cli_app()

--- a/src/disp_s1/cli/__init__.py
+++ b/src/disp_s1/cli/__init__.py
@@ -1,5 +1,6 @@
 import click
 
+from .download import download_ionosphere
 from .make_browse import make_browse
 from .run import run_cli
 from .validate import validate
@@ -19,6 +20,7 @@ def cli_app(ctx: click.Context, debug: bool) -> None:
 cli_app.add_command(run_cli)
 cli_app.add_command(validate)
 cli_app.add_command(make_browse)
+cli_app.add_command(download_ionosphere)
 
 if __name__ == "__main__":
     cli_app()

--- a/src/disp_s1/cli/download.py
+++ b/src/disp_s1/cli/download.py
@@ -2,6 +2,8 @@ from collections.abc import Sequence
 from pathlib import Path
 
 import click
+import opera_utils.geometry
+from opera_utils import get_burst_ids_for_frame
 
 from disp_s1.ionosphere import (
     DEFAULT_DOWNLOAD_ENDPOINT,
@@ -11,7 +13,12 @@ from disp_s1.ionosphere import (
 )
 
 
-@click.command()
+@click.group(name="download")
+def download_group():
+    """Sub-commands for downloading prerequisite data."""
+
+
+@download_group.command()
 @click.argument("input_files", type=str, nargs=-1, required=True)
 @click.option(
     "--output-dir",
@@ -35,7 +42,7 @@ from disp_s1.ionosphere import (
     default=DEFAULT_DOWNLOAD_ENDPOINT,
     help="CDDIS download endpoint",
 )
-def download_ionosphere(
+def ionosphere(
     input_files: Sequence[Path],
     output_dir: Path,
     ionosphere_type: IonosphereType,
@@ -60,3 +67,58 @@ def download_ionosphere(
 
     for file in downloaded_files:
         click.echo(f"Downloaded: {file}")
+
+
+@download_group.command()
+@click.option("--frame-id", type=int, help="Sentinel-1 OPERA Frame ID")
+@click.option(
+    "--output-dir",
+    "-o",
+    type=click.Path(file_okay=False, path_type=Path),
+    required=True,
+    help="Directory to save downloaded static layers",
+)
+@click.option(
+    "--max-jobs",
+    "-j",
+    type=int,
+    default=4,
+    help="Maximum number of concurrent downloads",
+)
+@click.option(
+    "--burst-ids",
+    "-b",
+    type=str,
+    multiple=True,
+    help=(  # noqa: E501
+        "Optional specific burst IDs to download. If not provided, gets all bursts for"
+        " frame."
+    ),
+)
+def static_layers(
+    frame_id: int,
+    output_dir: Path,
+    max_jobs: int,
+    burst_ids: Sequence[str] | None = None,
+) -> None:
+    """Download CSLC static layers for a given frame ID.
+
+    If specific burst IDs are not provided, downloads static layers for all bursts
+    in the frame. The output directory must exist.
+
+    """
+    # Use provided burst IDs or get all bursts for frame
+    bursts_to_download = (
+        list(burst_ids) if burst_ids else get_burst_ids_for_frame(frame_id)
+    )
+
+    click.echo(
+        f"Downloading static layers for {len(bursts_to_download)} bursts:"
+        f" {bursts_to_download}"
+    )
+
+    opera_utils.geometry.download_cslc_static_layers(
+        burst_ids=bursts_to_download, output_dir=output_dir, max_jobs=max_jobs
+    )
+
+    click.echo("Download complete")

--- a/src/disp_s1/cli/download.py
+++ b/src/disp_s1/cli/download.py
@@ -2,7 +2,6 @@ from collections.abc import Sequence
 from pathlib import Path
 
 import click
-import opera_utils.geometry
 from opera_utils import get_burst_ids_for_frame
 
 from disp_s1.ionosphere import (
@@ -90,7 +89,7 @@ def ionosphere(
     "-b",
     type=str,
     multiple=True,
-    help=(  # noqa: E501
+    help=(
         "Optional specific burst IDs to download. If not provided, gets all bursts for"
         " frame."
     ),
@@ -107,6 +106,8 @@ def static_layers(
     in the frame. The output directory must exist.
 
     """
+    import opera_utils.geometry
+
     # Use provided burst IDs or get all bursts for frame
     bursts_to_download = (
         list(burst_ids) if burst_ids else get_burst_ids_for_frame(frame_id)

--- a/src/disp_s1/cli/download.py
+++ b/src/disp_s1/cli/download.py
@@ -35,7 +35,6 @@ from disp_s1.ionosphere import (
     default=DEFAULT_DOWNLOAD_ENDPOINT,
     help="CDDIS download endpoint",
 )
-@click.option("--verbose", "-v", is_flag=True, help="Enable verbose logging")
 def download_ionosphere(
     input_files: Sequence[Path],
     output_dir: Path,
@@ -59,15 +58,5 @@ def download_ionosphere(
     )
     downloaded_files = download_ionosphere_files(config)
 
-    config = DownloadConfig(
-        input_files=list(input_files),
-        output_dir=output_dir,
-        ionosphere_type=ionosphere_type,
-        username=username,
-        password=password,
-        download_endpoint=download_endpoint,
-    )
-
-    downloaded_files = download_ionosphere_files(config)
     for file in downloaded_files:
         click.echo(f"Downloaded: {file}")

--- a/src/disp_s1/cli/download.py
+++ b/src/disp_s1/cli/download.py
@@ -1,0 +1,73 @@
+from collections.abc import Sequence
+from pathlib import Path
+
+import click
+
+from disp_s1.ionosphere import (
+    DEFAULT_DOWNLOAD_ENDPOINT,
+    DownloadConfig,
+    IonosphereType,
+    download_ionosphere_files,
+)
+
+
+@click.command()
+@click.argument("input_files", type=str, nargs=-1, required=True)
+@click.option(
+    "--output-dir",
+    "-o",
+    type=Path,
+    default=Path.cwd(),
+    help="Directory to save downloaded files",
+)
+@click.option(
+    "--type",
+    "-t",
+    "ionosphere_type",
+    type=click.Choice([v.value for v in IonosphereType]),
+    default=IonosphereType.JPLG.value,
+    help="Type of ionosphere file to download",
+)
+@click.option("--username", "-u", help="EarthData Login username (if no ~/.netrc)")
+@click.option("--password", "-p", help="EarthData Login password (if no ~/.netrc)")
+@click.option(
+    "--download-endpoint",
+    default=DEFAULT_DOWNLOAD_ENDPOINT,
+    help="CDDIS download endpoint",
+)
+@click.option("--verbose", "-v", is_flag=True, help="Enable verbose logging")
+def download_ionosphere(
+    input_files: Sequence[Path],
+    output_dir: Path,
+    ionosphere_type: IonosphereType,
+    username: str | None,
+    password: str | None,
+    download_endpoint: str,
+):
+    """Download ionosphere correction files for Sentinel-1 data.
+
+    INPUT_FILES: One or more SAFE or CSLC files to download ionosphere data for.
+    Multiple files can be specified as space-separated arguments.
+    """
+    config = DownloadConfig(
+        input_files=list(input_files),
+        output_dir=output_dir,
+        ionosphere_type=IonosphereType(ionosphere_type),
+        username=username,
+        password=password,
+        download_endpoint=download_endpoint,
+    )
+    downloaded_files = download_ionosphere_files(config)
+
+    config = DownloadConfig(
+        input_files=list(input_files),
+        output_dir=output_dir,
+        ionosphere_type=ionosphere_type,
+        username=username,
+        password=password,
+        download_endpoint=download_endpoint,
+    )
+
+    downloaded_files = download_ionosphere_files(config)
+    for file in downloaded_files:
+        click.echo(f"Downloaded: {file}")

--- a/src/disp_s1/ionosphere.py
+++ b/src/disp_s1/ionosphere.py
@@ -1,110 +1,340 @@
+"""Download Ionosphere correction files from NASA CDDIS archive.
+
+Code adapted from OPERA PCM:
+https://github.com/nasa/opera-sds-pcm/blob/1e86f6980edc42e6f326439d9166b62d622a8984/tools/stage_ionosphere_file.py
+
+This script downloads ionosphere correction files corresponding to the acquisition
+dates of input Sentinel-1 SLC or CSLC files. It supports both legacy and new
+CDDIS archive naming conventions and handles authentication through EarthData Login.
+"""
+
+from __future__ import annotations
+
+import datetime
 import logging
+import netrc
+import re
 import subprocess
-from datetime import date
+from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
-from typing import Sequence
 
-from dolphin._types import Filename
-from opera_utils import group_by_date
+import requests
 
+# Constants
+DEFAULT_EDL_ENDPOINT = "urs.earthdata.nasa.gov"
+DEFAULT_DOWNLOAD_ENDPOINT = "https://cddis.nasa.gov/archive/gnss/products/ionex"
+
+
+# Type aliases
+class IonosphereType(str, Enum):
+    """Type of ionosphere file to download."""
+
+    JPLG = "jplg"
+    JPRG = "jprg"
+
+
+# Configure logging
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
 
 
-def download_ionex_for_slcs(
-    input_files: Sequence[Filename],
-    dest_dir: Filename,
-    verbose: bool = False,
-) -> list[Path]:
-    """Download IONEX files for a list of SLC files.
+class IonosphereFileNotFoundError(Exception):
+    """Raised when a requested ionosphere file cannot be found in the archive."""
 
-    Parameters
-    ----------
-    input_files : Sequence[Path]
-        List of SLC files.
-    dest_dir : Path
-        Directory to save the downloaded files.
-    verbose : bool, optional
-        Print messages, by default False.
+    pass
 
-    Returns
-    -------
-    list[Path]
-        List of downloaded IONEX files.
 
+class SessionWithHeaderRedirection(requests.Session):
+    """Class to maintain headers after EarthData Login redirect.
+
+    This code was adapted from the examples available here:
+    https://urs.earthdata.nasa.gov/documentation/for_users/data_access/python
     """
-    date_to_file_list = group_by_date(input_files)
-    logger.info(f"Found {len(date_to_file_list)} dates in the input files.")
 
-    output_files = []
-    for input_date_tuple, _file_list in date_to_file_list.items():
-        input_date = input_date_tuple[0]
-        logger.info("Downloading for %s", input_date)
-        f = download_ionex_for_date(input_date, dest_dir=dest_dir, verbose=verbose)
-        output_files.append(f)
+    def __init__(self, username, password, auth_host=DEFAULT_EDL_ENDPOINT):
+        """Initialize the SessionWithHeaderRedirection class."""
+        super().__init__()
+        self.auth = (username, password)
+        self.auth_host = auth_host
 
-    return output_files
+    # Overrides from the library to keep headers when redirected to or from
+    # the NASA auth host.
+    def rebuild_auth(self, prepared_request, response):
+        """Maintain authentication through redirects.
+
+        Parameters
+        ----------
+        prepared_request : requests.PreparedRequest
+            The new request to be sent
+        response : requests.Response
+            The response that triggered this rebuild
+
+        """
+        headers = prepared_request.headers
+        url = prepared_request.url
+
+        if "Authorization" in headers:
+            original_parsed = requests.utils.urlparse(response.request.url)
+            redirect_parsed = requests.utils.urlparse(url)
+            if (
+                (original_parsed.hostname != redirect_parsed.hostname)
+                and redirect_parsed.hostname != self.auth_host
+                and original_parsed.hostname != self.auth_host
+            ):
+                del headers["Authorization"]
 
 
-def download_ionex_for_date(
-    input_date: date,
-    dest_dir: Filename,
-    solution_code: str = "jpl",
-    verbose: bool = False,
-) -> Path:
-    """Download one IONEX file for a given date.
+@dataclass
+class ArchiveDate:
+    """Container for archive date information."""
+
+    year: str
+    doy: str
+
+    @classmethod
+    def from_date_str(cls, date_str: str) -> "ArchiveDate":
+        """Create ArchiveDate from YYYYMMDD formatted string.
+
+        Parameters
+        ----------
+        date_str : str
+            Date string in YYYYMMDD format
+
+        Returns
+        -------
+        ArchiveDate
+            Container with parsed year and day of year
+
+        """
+        dt = datetime.datetime.strptime(date_str, "%Y%m%d")
+        time_tuple = dt.timetuple()
+        return cls(year=str(time_tuple.tm_year), doy=f"{time_tuple.tm_yday:03d}")
+
+
+def parse_safe_date(filename: Path | str) -> str:
+    """Extract acquisition date from Sentinel-1 SAFE filename.
 
     Parameters
     ----------
-    input_date: date
-        The date to download.
-    dest_dir : Path
-        Directory to save the downloaded files.
-    solution_code : str, optional
-        Analysis center code, by default "jpl".
-    verbose : bool, optional
-        Print messages, by default False.
-
-    Returns
-    -------
-    Path
-        Path to the local IONEX text file.
-
-    """
-    source_url = _generate_ionex_filename(input_date, solution_code=solution_code)
-    dest_file = Path(dest_dir) / Path(source_url).name
-
-    wget_cmd = ["wget", "--continue", "--auth-no-challenge", source_url]
-
-    if not verbose:
-        wget_cmd.append("--quiet")
-
-    logger.info('Running command: "%s"', " ".join(wget_cmd))
-    subprocess.run(wget_cmd, cwd=dest_dir, check=False)
-    return dest_file
-
-
-def _generate_ionex_filename(input_date: date, solution_code: str = "jpl") -> str:
-    """Generate the IONEX file name.
-
-    Parameters
-    ----------
-    input_date : datetime
-        Date to download
-    solution_code : str, optional
-        GIM analysis center code, by default "jpl".
-    date_format : str, optional
-        Date format code, by default "%Y%m%d".
+    filename : str or Path
+        Path to SAFE archive or its filename
 
     Returns
     -------
     str
-        Complete URL to the IONEX file.
+        Acquisition date in YYYYMMDD format
+
+    Raises
+    ------
+    ValueError
+        If filename does not match expected SAFE naming convention
 
     """
-    day_of_year = f"{input_date.timetuple().tm_yday:03d}"
-    year_short = str(input_date.year)[2:4]
-    file_name = f"{solution_code.lower()}g{day_of_year}0.{year_short}i.Z"
+    safe_name = Path(filename).stem
 
-    url_directory = "https://cddis.nasa.gov/archive/gnss/products/ionex"
-    return f"{url_directory}/{input_date.year}/{day_of_year}/{file_name}"
+    pattern = (
+        r"(?P<mission_id>S1A|S1B)_(?P<beam_mode>IW)_(?P<product_type>SLC)(?P<resolution>_)_"
+        r"(?P<level>1)(?P<class>S)(?P<pol>SH|SV|DH|DV)_(?P<start_ts>\d{8}T\d{6})_"
+        r"(?P<stop_ts>\d{8}T\d{6})_(?P<orbit_num>\d{6})_(?P<data_take_id>[0-9A-F]{6})_"
+        r"(?P<product_id>[0-9A-F]{4})"
+    )
+
+    match = re.match(pattern, safe_name)
+    if not match:
+        raise ValueError(f"Invalid SAFE filename format: {filename}")
+
+    return match.group("start_ts").split("T")[0]
+
+
+def parse_cslc_date(filename: Path | str) -> str:
+    """Extract acquisition date from OPERA CSLC filename.
+
+    Parameters
+    ----------
+    filename : str or Path
+        Path to CSLC archive or its filename
+
+    Returns
+    -------
+    str
+        Acquisition date in YYYYMMDD format
+
+    Raises
+    ------
+    ValueError
+        If filename does not match expected CSLC naming convention
+
+    """
+    cslc_name = Path(filename).stem
+
+    pattern = (
+        r"OPERA_L2_(COMPRESSED-)?CSLC-S1_(?P<burst_id>\w{4}-\w{6}-\w{3})_"
+        r"(?P<acquisition_ts>\d{8}T\d{6})Z_.*"
+    )
+
+    match = re.match(pattern, cslc_name)
+    if not match:
+        raise ValueError(f"Invalid CSLC filename format: {filename}")
+
+    return match.group("acquisition_ts").split("T")[0]
+
+
+def get_archive_name(
+    ionosphere_type: IonosphereType, archive_date: ArchiveDate, legacy: bool = False
+) -> str:
+    """Generate ionosphere archive filename.
+
+    Parameters
+    ----------
+    ionosphere_type : {'jplg', 'jprg'}
+        Type of ionosphere file to download
+    archive_date : ArchiveDate
+        Container with year and day of year
+    legacy : bool, optional
+        If True, use legacy naming convention, by default False
+
+    Returns
+    -------
+    str
+        Generated archive filename
+
+    """
+    if legacy:
+        return f"{ionosphere_type.value}{archive_date.doy}0.{archive_date.year[2:]}i.Z"
+
+    product_type = "RAP" if ionosphere_type == "jprg" else "FIN"
+    return f"JPL0OPS{product_type}_{archive_date.year}{archive_date.doy}0000_01D_02H_GIM.INX.gz"  # noqa: E501
+
+
+def download_ionosphere_file(
+    url: str, output_dir: Path, session: requests.Session
+) -> Path:
+    """Download and extract ionosphere file.
+
+    Parameters
+    ----------
+    url : str
+        URL of the ionosphere file to download
+    output_dir : Path
+        Directory to save the downloaded file
+    session : requests.Session
+        Authenticated session for downloading
+
+    Returns
+    -------
+    Path
+        Path to the extracted ionosphere file
+
+    Raises
+    ------
+    requests.exceptions.HTTPError
+        If download fails
+
+    """
+    response = session.get(url, stream=True)
+    response.raise_for_status()
+
+    archive_path = output_dir / Path(url).name
+    with open(archive_path, "wb") as f:
+        for chunk in response.iter_content(chunk_size=1024 * 1024):
+            f.write(chunk)
+
+    # Extract the downloaded file
+    result = subprocess.run(
+        ["gunzip", "-c", str(archive_path)], check=True, capture_output=True
+    )
+
+    output_path = archive_path.with_suffix("")
+    output_path.write_bytes(result.stdout)
+
+    # Clean up compressed file
+    archive_path.unlink()
+
+    return output_path
+
+
+@dataclass
+class DownloadConfig:
+    """Configuration for ionosphere file download."""
+
+    input_files: list[Path]
+    output_dir: Path
+    ionosphere_type: IonosphereType = IonosphereType("jplg")
+    username: str | None = None
+    password: str | None = None
+    download_endpoint: str = DEFAULT_DOWNLOAD_ENDPOINT
+
+
+def download_ionosphere_files(config: DownloadConfig) -> list[Path]:
+    """Download ionosphere files for multiple input files.
+
+    Parameters
+    ----------
+    config : DownloadConfig
+        Download configuration parameters
+
+    Returns
+    -------
+    list[Path]
+        Paths to downloaded ionosphere files
+
+    Raises
+    ------
+    ValueError
+        If authentication credentials are missing
+    IonosphereFileNotFoundError
+        If a required ionosphere file cannot be found
+
+    """
+    # Get credentials if not provided
+    username = config.username
+    password = config.password
+
+    if not (username and password):
+        try:
+            parsed = netrc.netrc().authenticators(DEFAULT_EDL_ENDPOINT)
+            assert parsed is not None
+            username, _, password = parsed
+        except (FileNotFoundError, TypeError):
+            raise ValueError(
+                "No authentication credentials provided and none found in .netrc"
+            )
+
+    session = SessionWithHeaderRedirection(username, password)
+    downloaded_files = []
+
+    for input_file in config.input_files:
+        # Try parsing as SAFE first, then CSLC
+        try:
+            date_str = parse_safe_date(input_file)
+        except ValueError:
+            try:
+                date_str = parse_cslc_date(input_file)
+            except ValueError:
+                raise ValueError(
+                    f"File {input_file} does not match SAFE or CSLC naming convention"
+                )
+
+        archive_date = ArchiveDate.from_date_str(date_str)
+
+        # Try both naming conventions
+        found = False
+        for legacy in (True, False):
+            archive_name = get_archive_name(
+                config.ionosphere_type, archive_date, legacy
+            )
+            url = f"{config.download_endpoint}/{archive_date.year}/{archive_date.doy}/{archive_name}"  # noqa: E501
+
+            response = session.head(url)
+            if response.status_code == 200:
+                output_file = download_ionosphere_file(url, config.output_dir, session)
+                downloaded_files.append(output_file)
+                found = True
+                break
+
+        if not found:
+            raise IonosphereFileNotFoundError(
+                f"No ionosphere file found for date {date_str}"
+            )
+
+    return downloaded_files

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import pytest
 from click.testing import CliRunner
 
 from disp_s1.cli import cli_app
@@ -19,3 +20,19 @@ def test_cli_debug():
     assert result.exit_code == 2
     assert result.output.startswith("Usage: disp-s1 [OPTIONS] COMMAND [ARGS]...\n")
     assert result.output.endswith("\n")
+
+
+# Check run, validate, download-ionosphere, make-browse
+@pytest.mark.parametrize(
+    "command",
+    [
+        "run",
+        "validate",
+        "download-ionosphere",
+        "make-browse",
+    ],
+)
+def test_cli_subcommands_smoke_test(command):
+    runner = CliRunner()
+    result = runner.invoke(cli_app, [command, "--help"])
+    assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,17 +22,31 @@ def test_cli_debug():
     assert result.output.endswith("\n")
 
 
-# Check run, validate, download-ionosphere, make-browse
+# Check run, validate, download, make-browse
 @pytest.mark.parametrize(
     "command",
     [
         "run",
+        "download",
         "validate",
-        "download-ionosphere",
         "make-browse",
     ],
 )
 def test_cli_subcommands_smoke_test(command):
     runner = CliRunner()
     result = runner.invoke(cli_app, [command, "--help"])
+    assert result.exit_code == 0
+
+
+# Check run, validate, download, make-browse
+@pytest.mark.parametrize(
+    "command",
+    [
+        "ionosphere",
+        "static-layers",
+    ],
+)
+def test_cli_download_subcommands_smoke_test(command):
+    runner = CliRunner()
+    result = runner.invoke(cli_app, ["download", command, "--help"])
     assert result.exit_code == 0


### PR DESCRIPTION
Uses Scott's logic, which has the fix for the >=2022-style naming.
Adds `disp-s1 download ionosphere` to stage ionosphere files for testing

(supercedes half of #39 )

Also adds a `disp-s1 download static-layers` for getting a frame's geometry files.