### PR TITLE
Add recommended_*_threshold to allow hard-coded thresholds for `recommended_mask` to vary

### DIFF
--- a/configs/algorithm_parameters_historical.yaml
+++ b/configs/algorithm_parameters_historical.yaml
@@ -321,3 +321,6 @@ spatial_wavelength_cutoff: 25000.0
 browse_image_vmin_vmax:
   - -0.1
   - 0.1
+# Number of output products to create in parallel.
+#   Type: integer.
+algorithm_parameters.num_parallel_products: 3

--- a/configs/algorithm_parameters_historical.yaml
+++ b/configs/algorithm_parameters_historical.yaml
@@ -312,6 +312,14 @@ output_options:
 # Name of the subdataset to use in the input NetCDF files.
 #   Type: string.
 subdataset: /data/VV
+# When creating `recommended_mask`, pixels with temporal coherence below this threshold and
+#   with similarity below `recommended_similarity_threshold` are masked.
+#   Type: number.
+recommended_temporal_coherence_threshold: 0.6
+# When creating `recommended_mask`, pixels with similarity below this threshold and with
+#   temporal coherence below `recommended_temporal_coherence_threshold` are masked.
+#   Type: number.
+recommended_similarity_threshold: 0.5
 # Spatial wavelength cutoff (in meters) for the spatial filter. Used to create the short
 #   wavelength displacement layer.
 #   Type: number.
@@ -323,4 +331,4 @@ browse_image_vmin_vmax:
   - 0.1
 # Number of output products to create in parallel.
 #   Type: integer.
-algorithm_parameters.num_parallel_products: 3
+num_parallel_products: 3

--- a/src/disp_s1/main.py
+++ b/src/disp_s1/main.py
@@ -22,7 +22,7 @@ from opera_utils.geometry import get_incidence_angles
 from disp_s1 import __version__, product
 from disp_s1._masking import create_layover_shadow_masks, create_mask_from_distance
 from disp_s1._ps import precompute_ps
-from disp_s1.pge_runconfig import RunConfig
+from disp_s1.pge_runconfig import AlgorithmParameters, RunConfig
 
 from ._reference import ReferencePoint, read_reference_point
 from ._utils import (
@@ -236,6 +236,10 @@ def create_products(
         logger.warning("Using approximate incidence angles")
         near_far_incidence_angles = 30.0, 45.0
 
+    algorithm_parameters = AlgorithmParameters.from_yaml(
+        pge_runconfig.dynamic_ancillary_file_group.algorithm_parameters_file
+    )
+
     logger.info(f"Creating {len(out_paths.timeseries_paths)} outputs in {out_dir}")
     # Group all the CSLCs by date to pick out ref/secondaries
     date_to_cslc_files = group_by_date(cfg.cslc_file_list, date_idx=0)
@@ -251,7 +255,7 @@ def create_products(
         los_north_file=los_north_file,
         near_far_incidence_angles=near_far_incidence_angles,
         water_mask=matching_water_binary_mask,
-        max_workers=3,
+        max_workers=algorithm_parameters.num_parallel_products,
     )
     logger.info("Finished creating output products.")
 

--- a/src/disp_s1/pge_runconfig.py
+++ b/src/disp_s1/pge_runconfig.py
@@ -207,6 +207,9 @@ class AlgorithmParameters(YamlModel):
             " creator."
         ),
     )
+    num_parallel_products: int = Field(
+        3, description="Number of output products to create in parallel."
+    )
 
     model_config = ConfigDict(extra="forbid")
 

--- a/src/disp_s1/pge_runconfig.py
+++ b/src/disp_s1/pge_runconfig.py
@@ -192,6 +192,22 @@ class AlgorithmParameters(YamlModel):
         description="Name of the subdataset to use in the input NetCDF files.",
     )
 
+    recommended_temporal_coherence_threshold: float = Field(
+        0.6,
+        description=(
+            "When creating `recommended_mask`, pixels with temporal coherence below"
+            " this threshold and with similarity below"
+            " `recommended_similarity_threshold` are masked."
+        ),
+    )
+    recommended_similarity_threshold: float = Field(
+        0.5,
+        description=(
+            "When creating `recommended_mask`, pixels with similarity below this"
+            " threshold and with temporal coherence below"
+            " `recommended_temporal_coherence_threshold` are masked."
+        ),
+    )
     # Extra product creation options
     spatial_wavelength_cutoff: float = Field(
         25_000,

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -259,8 +259,11 @@ def create_output_product(
 
     # Mark pixels that are bad
     is_zero_conncomp = conncomps == 0
-    bad_temporal_coherence = temporal_coherence < 0.6
-    bad_similarity = similarity < 0.5
+    bad_temporal_coherence = (
+        temporal_coherence
+        < algorithm_parameters.recommended_temporal_coherence_threshold
+    )
+    bad_similarity = similarity < algorithm_parameters.recommended_similarity_threshold
     is_low_quality = bad_temporal_coherence & bad_similarity
 
     # If a pixel has any of the reasons to be bad, recommend masking

--- a/tests/test_pge_runconfig.py
+++ b/tests/test_pge_runconfig.py
@@ -97,6 +97,37 @@ def runconfig_minimum(
     return c
 
 
+def test_algorithm_parameters_defaults():
+    """Test that AlgorithmParameters has the expected default values."""
+    from dolphin.workflows import (
+        InterferogramNetwork,
+        OutputOptions,
+        PhaseLinkingOptions,
+        PsOptions,
+        TimeseriesOptions,
+        UnwrapOptions,
+    )
+
+    params = AlgorithmParameters()
+
+    # Check direct attributes
+    assert params.algorithm_parameters_overrides_json is None
+    assert params.subdataset == "/data/VV"
+    assert params.recommended_temporal_coherence_threshold == 0.6
+    assert params.recommended_similarity_threshold == 0.5
+    assert params.spatial_wavelength_cutoff == 25_000
+    assert params.browse_image_vmin_vmax == (-0.10, 0.10)
+    assert params.num_parallel_products == 3
+
+    # Check that nested objects are created with their default factories
+    assert isinstance(params.ps_options, PsOptions)
+    assert isinstance(params.phase_linking, PhaseLinkingOptions)
+    assert isinstance(params.interferogram_network, InterferogramNetwork)
+    assert isinstance(params.unwrap_options, UnwrapOptions)
+    assert isinstance(params.timeseries_options, TimeseriesOptions)
+    assert isinstance(params.output_options, OutputOptions)
+
+
 def test_runconfig_to_yaml(runconfig_minimum):
     print(runconfig_minimum.to_yaml(sys.stdout))
 


### PR DESCRIPTION
The `0.6` and `0.5` numbers seem a bit risky to have hardcoded, with low downside to including them here for an easier change than a SDS re-deployment.