### PR TITLE
Fix `processing_start_datetime`, nodata values for 0-1 rasters

### DIFF
--- a/src/disp_s1/main.py
+++ b/src/disp_s1/main.py
@@ -476,10 +476,8 @@ def create_displacement_products(
     processing_start_datetime : datetime.datetime
         The processing start datetime.
     reference_point : ReferencePoint, optional
-        Named tuple with (row, col, lat, lon) of selected reference pixel.
-        If None, will record empty in the dataset's attributes
-    reference_point : ReferencePoint, optional
-        Reference point recorded from dolphin after unwrapping.
+        Named tuple with (row, col, lat, lon) of selected reference pixel
+        recorded from dolphin after unwrapping.
         If none, leaves product attributes empty.
     los_east_file : Path, optional
         Path to the east component of line of sight unit vector
@@ -533,11 +531,11 @@ def create_displacement_products(
                 repeat(date_to_cslc_files),
                 repeat(pge_runconfig),
                 repeat(dolphin_config),
+                repeat(processing_start_datetime),
                 repeat(reference_point),
                 repeat(los_east_file),
                 repeat(los_north_file),
                 repeat(near_far_incidence_angles),
-                repeat(processing_start_datetime),
             )
         )
 

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -352,7 +352,8 @@ def create_output_product(
 
         for info, filename in zip(product_infos[3:], data_files, strict=True):
             if filename is not None and Path(filename).exists():
-                data = io.load_gdal(filename).astype(info.dtype)
+                data = io.load_gdal(filename, masked=True).filled(info.fillvalue)
+                data = data.astype(info.dtype)
             else:
                 data = np.full(shape=shape, fill_value=info.fillvalue, dtype=info.dtype)
 


### PR DESCRIPTION
The `fillvalue` has been set to nan, but the out of bounds values are all 0.