### PR TITLE
Fix the output_reference_idx to be the last compressed SLC during `RunConfig.to_workflow()`

### DIFF
--- a/src/disp_s1/pge_runconfig.py
+++ b/src/disp_s1/pge_runconfig.py
@@ -499,8 +499,7 @@ def _compute_reference_dates(
     # So we should make the output index relative to the most recent compressed SLC
     # https://github.com/isce-framework/dolphin/blob/14ac66e49a8e8e66e9b74fc9eb4f0d232ab0924c/src/dolphin/stack.py#L488
     if compressed_slc_plan == CompressedSlcPlan.LAST_PER_MINISTACK:
-        output_reference_idx = num_ccslc - 1
-
+        output_reference_idx = max(0, num_ccslc - 1)
     return output_reference_idx, extra_reference_date
 
 

--- a/src/disp_s1/pge_runconfig.py
+++ b/src/disp_s1/pge_runconfig.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import datetime
 import json
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from pathlib import Path
 from typing import Any, ClassVar, List, Optional, Union
 
+from dolphin.stack import CompressedSlcPlan
 from dolphin.workflows.config import (
     CorrectionOptions,
     DisplacementWorkflow,
@@ -18,11 +19,12 @@ from dolphin.workflows.config import (
     TimeseriesOptions,
     UnwrapOptions,
     WorkerSettings,
+    YamlModel,
 )
 from dolphin.workflows.config._common import _read_file_list_or_glob
-from dolphin.workflows.config._yaml_model import YamlModel
 from opera_utils import (
     OPERA_DATASET_NAME,
+    PathOrStr,
     get_burst_ids_for_frame,
     get_dates,
     get_frame_bbox,
@@ -296,7 +298,8 @@ class RunConfig(YamlModel):
         )
         new_parameters = _override_parameters(algorithm_parameters, frame_id=frame_id)
         # regenerate to ensure all defaults remained in updated version
-        param_dict = AlgorithmParameters(**new_parameters.model_dump()).model_dump()
+        algo_params = AlgorithmParameters(**new_parameters.model_dump())
+        param_dict = algo_params.model_dump()
 
         # Convert the frame_id into an output bounding box
         frame_to_burst_file = self.static_ancillary_file_group.frame_to_burst_json
@@ -330,7 +333,9 @@ class RunConfig(YamlModel):
         )
         # Compute the requested output indexes
         output_reference_idx, extra_reference_date = _compute_reference_dates(
-            reference_datetimes, cslc_file_list
+            reference_datetimes,
+            cslc_file_list,
+            algo_params.phase_linking.compressed_slc_plan,
         )
         param_dict["phase_linking"]["output_reference_idx"] = output_reference_idx
         param_dict["output_options"]["extra_reference_date"] = extra_reference_date
@@ -435,8 +440,8 @@ def _override_parameters(
 
 
 def _get_first_after_selected(
-    input_dates: Sequence[datetime.datetime],
-    selected_date: datetime.datetime,
+    input_dates: Sequence[datetime.datetime | datetime.date],
+    selected_date: datetime.datetime | datetime.date,
 ) -> int:
     """Find the first index of `input_dates` which falls after `selected_date`."""
     for idx, d in enumerate(input_dates):
@@ -447,16 +452,20 @@ def _get_first_after_selected(
 
 
 def _compute_reference_dates(
-    reference_datetimes, cslc_file_list
+    reference_datetimes: Iterable[datetime.datetime],
+    cslc_file_list: Iterable[PathOrStr],
+    compressed_slc_plan: CompressedSlcPlan,
 ) -> tuple[int, datetime.datetime | None]:
     # Get the dates of the base phase (works for either compressed, or regular cslc)
     # Use one burst ID as the template.
     burst_to_file_list = group_by_burst(cslc_file_list)
     burst_id = list(burst_to_file_list.keys())[0]
+    # Extract this burst id's files
     cur_files = sort_files_by_date(burst_to_file_list[burst_id])[0]
     # Mark any files beginning with "compressed" as compressed
     is_compressed = ["compressed" in str(Path(f).stem).lower() for f in cur_files]
     input_dates = [get_dates(f)[0].date() for f in cur_files]
+    num_ccslc = sum(is_compressed)
 
     output_reference_idx: int = 0
     extra_reference_date: datetime.datetime | None = None
@@ -477,12 +486,20 @@ def _compute_reference_dates(
             # Update the output_reference_idx for compressed SLCs
             output_reference_idx = nearest_idx
             # But if it's a compressed SLC, it's not an "extra" reference date
+            # This will move forward in time as we iterate over the reference dates
         else:
             # Set extra_reference_date for non-compressed SLCs
             inp_date = input_dates[nearest_idx]
             # Don't use this SLC if it's before the requested changeover; only after
             if inp_date >= ref_date:
                 extra_reference_date = inp_date
+
+    # If we have set the compressed_slc_plan to be the last per ministack,
+    # we want to make the shortest baseline interferograms.
+    # So we should make the output index relative to the most recent compressed SLC
+    # https://github.com/isce-framework/dolphin/blob/14ac66e49a8e8e66e9b74fc9eb4f0d232ab0924c/src/dolphin/stack.py#L488
+    if compressed_slc_plan == CompressedSlcPlan.LAST_PER_MINISTACK:
+        output_reference_idx = num_ccslc - 1
 
     return output_reference_idx, extra_reference_date
 

--- a/tests/test_pge_runconfig.py
+++ b/tests/test_pge_runconfig.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import opera_utils
 import pytest
+from dolphin.stack import CompressedSlcPlan
 
 from disp_s1 import pge_runconfig
 from disp_s1.pge_runconfig import (
@@ -245,6 +246,23 @@ def test_reference_changeover(
     assert cfg.output_options.extra_reference_date == datetime.datetime(2018, 7, 22)
 
 
+def _make_frame_files(
+    sensing_time_list: list[datetime.datetime], num_compressed: int
+) -> list[str]:
+    comp_slcs = [
+        # Note the fake (start, end) datetimes since we dont use those for these testes
+        f"COMPRESSED_OPERA_T042-088905-{swath}_{d.strftime('%Y%m%dT%H%M%S')}_20200101_20210101.h5"
+        for d in sensing_time_list[:num_compressed]
+        for swath in ["IW1", "IW2", "IW3"]
+    ]
+    real_slcs = [
+        f"OPERA_T042-088905-{swath}_{d.strftime('%Y%m%dT%H%M%S')}.h5"
+        for d in sensing_time_list[num_compressed:]
+        for swath in ["IW1", "IW2", "IW3"]
+    ]
+    return comp_slcs + real_slcs
+
+
 def test_reference_date_computation():
     # Test from a sample alaska frame after dropping winter
     # it spans multiple years
@@ -265,12 +283,7 @@ def test_reference_date_computation():
         datetime.datetime(2020, 8, 21, 16, 13, 4),
         datetime.datetime(2020, 9, 2, 16, 13, 5),
     ]
-    # Doesn't have to be the real name
-    cslc_file_list = [
-        f"OPERA_T042-088905-{swath}_{d.strftime('%Y%m%dT%H%M%S')}.h5"
-        for d in sensing_time_list
-        for swath in ["IW1", "IW2", "IW3"]
-    ]
+    cslc_file_list = _make_frame_files(sensing_time_list, 0)
     random.shuffle(cslc_file_list)
 
     # Assume we nominally will reset the reference each august
@@ -281,7 +294,9 @@ def test_reference_date_computation():
     # - the "extra reference date" will be the *latest* one from the reference list
     # this is be 2020-08-09
     output_reference_idx, extra_reference_date = pge_runconfig._compute_reference_dates(
-        reference_datetimes, cslc_file_list
+        reference_datetimes,
+        cslc_file_list,
+        compressed_slc_plan=CompressedSlcPlan.ALWAYS_FIRST,
     )
     assert output_reference_idx == 0
     assert extra_reference_date == datetime.date(2020, 8, 9)
@@ -305,11 +320,7 @@ def test_reference_first_in_stack():
         datetime.datetime(2017, 3, 26, 0, 0),
         datetime.datetime(2017, 4, 7, 0, 0),
     ]
-    cslc_file_list = [
-        f"OPERA_T042-088905-{swath}_{d.strftime('%Y%m%dT%H%M%S')}.h5"
-        for d in sensing_time_list
-        for swath in ["IW1", "IW2", "IW3"]
-    ]
+    cslc_file_list = _make_frame_files(sensing_time_list, 0)
     random.shuffle(cslc_file_list)
 
     # Assume we nominally will reset the reference each august
@@ -334,7 +345,9 @@ def test_reference_first_in_stack():
     # - The "output index" should be 0: this is the first ministack
     # - the "extra reference date" will be the None
     output_reference_idx, extra_reference_date = pge_runconfig._compute_reference_dates(
-        reference_datetimes, cslc_file_list
+        reference_datetimes,
+        cslc_file_list,
+        compressed_slc_plan=CompressedSlcPlan.ALWAYS_FIRST,
     )
     assert output_reference_idx == 0
     assert extra_reference_date is None
@@ -365,7 +378,9 @@ def test_repeated_compressed_dates():
     ]
 
     output_reference_idx, extra_reference_date = pge_runconfig._compute_reference_dates(
-        reference_datetimes, cslc_file_list
+        reference_datetimes,
+        cslc_file_list,
+        compressed_slc_plan=CompressedSlcPlan.ALWAYS_FIRST,
     )
     # Should be the latest one: the compressed slc with 20200717
     assert output_reference_idx == 4
@@ -373,8 +388,56 @@ def test_repeated_compressed_dates():
 
 
 def test_reference_date_last_per_ministack():
-    # TODO
-    assert False
+    compressed_slc_plan = CompressedSlcPlan.LAST_PER_MINISTACK
+    sensing_time_list = [
+        datetime.datetime(2016, 8, 10, 0, 0),
+        datetime.datetime(2016, 9, 3, 0, 0),
+        datetime.datetime(2016, 9, 27, 0, 0),
+        datetime.datetime(2016, 10, 21, 0, 0),
+        datetime.datetime(2016, 11, 14, 0, 0),
+        datetime.datetime(2016, 12, 8, 0, 0),
+        datetime.datetime(2017, 1, 1, 0, 0),
+        datetime.datetime(2017, 1, 13, 0, 0),
+        datetime.datetime(2017, 1, 19, 0, 0),
+        datetime.datetime(2017, 1, 25, 0, 0),
+        datetime.datetime(2017, 2, 18, 0, 0),
+        datetime.datetime(2017, 3, 2, 0, 0),
+        datetime.datetime(2017, 3, 14, 0, 0),
+        datetime.datetime(2017, 3, 26, 0, 0),
+        datetime.datetime(2017, 4, 7, 0, 0),
+    ]
+    cslc_file_list = _make_frame_files(
+        sensing_time_list=sensing_time_list, num_compressed=0
+    )
+    random.shuffle(cslc_file_list)
+
+    # Assume we nominally will reset the reference each august
+    reference_datetimes = []
+    # We expect that
+    # - The "output index" should be 0: this is the first ministack
+    # - the "extra reference date" will be the None
+    output_reference_idx, extra_reference_date = pge_runconfig._compute_reference_dates(
+        reference_datetimes, cslc_file_list, compressed_slc_plan=compressed_slc_plan
+    )
+    assert output_reference_idx == 0
+    assert extra_reference_date is None
+
+    # Now add compressed, and not that output reference index should be the latest one
+    for num_compressed in range(1, 6):
+        cslc_file_list = _make_frame_files(
+            sensing_time_list=sensing_time_list, num_compressed=num_compressed
+        )
+        random.shuffle(cslc_file_list)
+        output_reference_idx, extra_reference_date = (
+            pge_runconfig._compute_reference_dates(
+                reference_datetimes,
+                cslc_file_list,
+                compressed_slc_plan=compressed_slc_plan,
+            )
+        )
+        assert output_reference_idx == num_compressed - 1
+
+        assert extra_reference_date is None
 
 
 @pytest.fixture

--- a/tests/test_pge_runconfig.py
+++ b/tests/test_pge_runconfig.py
@@ -372,6 +372,11 @@ def test_repeated_compressed_dates():
     assert extra_reference_date is None
 
 
+def test_reference_date_last_per_ministack():
+    # TODO
+    assert False
+
+
 @pytest.fixture
 def overrides_file():
     return (


### PR DESCRIPTION
The current setup in Dolphin works using logic in `stack.py`; however, since disp-s1 runs in batches that are all separate, I've made the reference date stuff separate. 
The key addition:

```python
    # If we have set the compressed_slc_plan to be the last per ministack,
    # we want to make the shortest baseline interferograms.
    # So we should make the output index relative to the most recent compressed SLC
    # https://github.com/isce-framework/dolphin/blob/14ac66e49a8e8e66e9b74fc9eb4f0d232ab0924c/src/dolphin/stack.py#L488
    if compressed_slc_plan == CompressedSlcPlan.LAST_PER_MINISTACK:
        output_reference_idx = max(0, num_ccslc - 1)
```

the results are looking nice for hawaii
![image](https://github.com/user-attachments/assets/91834a81-479c-44d7-a05d-c393c50c19d6)

