### PR TITLE
Remove `/identification/mission_id` to avoid ambiguity from multi-sensor inputs

### DIFF
--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -1541,7 +1541,6 @@ def copy_cslc_metadata_to_displacement(
 
     # Add ones which should be same for both ref/sec
     common_dsets = [
-        ("/identification/mission_id", None),
         ("/identification/instrument_name", None),
         ("/identification/look_direction", None),
         ("/identification/track_number", None),


### PR DESCRIPTION
We now have `/identification/source_data_satellite_names` as the set of all sensors for inputs.