### PR TITLE
Fix parseing of reference dates for new format with metadata

### DIFF
--- a/src/disp_s1/pge_runconfig.py
+++ b/src/disp_s1/pge_runconfig.py
@@ -509,7 +509,11 @@ def _parse_reference_date_json(
     reference_datetimes: list[datetime.datetime] = []
     if reference_date_json is not None:
         with open(reference_date_json) as f:
-            reference_date_strs = json.load(f)[str(frame_id)]
+            reference_data = json.load(f)
+            if "data" in reference_data:
+                reference_date_strs = reference_data["data"].get(str(frame_id), [])
+            else:
+                reference_date_strs = reference_data.get(str(frame_id), [])
             reference_datetimes = [
                 datetime.datetime.fromisoformat(s) for s in reference_date_strs
             ]


### PR DESCRIPTION
Old format had top level keys of "831", ... (the frame ids).

New format has 
```
{
  "metadata": {
    "generation_time": "2025-01-15T16:04:54.848554",
    "consistent_json_file": "opera-disp-s1-consistent-burst-ids-2025-01-15-2016-07-01_to_2024-12-10.json",
    "interval": 1.0,
    "min_acquisitions": 15
  },
  "data": {
    "831": [
      "2016-07-02T23:05:35",
      "2017-07-09T23:05:41",
...
```
to better track the versions over time