### PR TITLE
Add missing iw2_mid_range to compressed SLC metadata

### DIFF
--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -1671,6 +1671,7 @@ def copy_cslc_metadata_to_compressed(
         ("/metadata/orbit", None),
         ("/metadata/processing_information/input_burst_metadata/wavelength", None),
         ("/metadata/processing_information/input_burst_metadata/platform_id", None),
+        ("/metadata/processing_information/input_burst_metadata/iw2_mid_range", None),
         (
             "/metadata/processing_information/input_burst_metadata/radar_center_frequency",
             None,


### PR DESCRIPTION
Addresses ISO XML metadata error in nasa/opera-sds-pge#567