### PR TITLE
Split footprint polygon on antimeridian

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,4 +40,4 @@ repos:
     rev: "25.1.0"
     hooks:
       - id: black
-        args: [--preview]
+        args: [--preview, --enable-unstable-feature, string_processing]

--- a/scripts/align_to_common_reference_date.py
+++ b/scripts/align_to_common_reference_date.py
@@ -71,7 +71,7 @@ def _make_gtiff_writer(output_dir, all_dates, like_filename, dataset: str):
     suffix = ".tif"
 
     out_paths = [
-        Path(output_dir) / (f"{dataset}_{format_dates(ref_date, d)}{suffix}")
+        Path(output_dir) / f"{dataset}_{format_dates(ref_date, d)}{suffix}"
         for d in all_dates[1:]
     ]
     output_dir.mkdir(exist_ok=True, parents=True)

--- a/scripts/release/convert_config.py
+++ b/scripts/release/convert_config.py
@@ -75,7 +75,7 @@ def main():
     parser.add_argument(
         "--reference_date_database_json",
         type=Path,
-        help=("JSON file containing list of reference date changes for each frame."),
+        help="JSON file containing list of reference date changes for each frame.",
     )
     parser.add_argument(
         "-a",

--- a/src/disp_s1/_utils.py
+++ b/src/disp_s1/_utils.py
@@ -7,12 +7,15 @@ from math import pi
 from multiprocessing import get_context
 from pathlib import Path
 
+import numpy as np
+import shapely.ops
 from dolphin import PathOrStr, io
 from dolphin.constants import SENTINEL_1_WAVELENGTH
 from dolphin.interferogram import estimate_correlation_from_phase
 from dolphin.unwrap import grow_conncomp_snaphu
 from dolphin.utils import full_suffix
 from dolphin.workflows.config import UnwrapOptions
+from shapely.geometry import LinearRing, MultiPolygon, Polygon
 from tqdm.contrib.concurrent import thread_map
 
 logger = logging.getLogger(__name__)
@@ -153,3 +156,107 @@ def _create_correlation_images(
     )
 
     return output_paths
+
+
+def extract_footprint(raster_path: PathOrStr, simplify_tolerance: float = 0.01) -> str:
+    """Extract a simplified footprint from a raster file.
+
+    This function opens a raster file, extracts its footprint, simplifies it,
+    and returns the a Polygon from the exterior ring as a WKT string.
+
+    Parameters
+    ----------
+    raster_path : str
+        Path to the input raster file.
+    simplify_tolerance : float, optional
+        Tolerance for simplification of the footprint geometry.
+        Default is 0.01.
+
+    Returns
+    -------
+    str
+        WKT string representing the simplified exterior footprint
+        in EPSG:4326 (lat/lon) coordinates.
+
+    Notes
+    -----
+    This function uses GDAL to open the raster and extract the footprint,
+    and Shapely to process the geometry.
+
+    """
+    from os import fspath
+
+    import shapely
+    from osgeo import gdal
+
+    # Extract the footprint as WKT string (don't save)
+    wkt = gdal.Footprint(
+        None,
+        fspath(raster_path),
+        format="WKT",
+        dstSRS="EPSG:4326",
+        simplify=simplify_tolerance,
+    )
+
+    # Convert WKT to Shapely geometry, extract exterior, and convert back to Polygon WKT
+    in_multi = shapely.from_wkt(wkt)
+
+    # This may have holes; get the exterior
+    # Largest polygon should be first in MultiPolygon returned by GDAL
+    footprint = shapely.Polygon(in_multi.geoms[0].exterior)
+    # Split on antimeridian and return the WKT string
+    return check_dateline(footprint).wkt
+
+
+def check_dateline(poly: Polygon) -> MultiPolygon:
+    """Split `poly` if it crosses the dateline.
+
+    Source:
+    https://github.com/nasa/opera-sds-pcm/blob/a5a3db25be462e7955e5de06d6f9d1d8236a1ef2/util/geo_util.py#L265
+
+    Parameters
+    ----------
+    poly : shapely.geometry.Polygon
+        Input polygon.
+
+    Returns
+    -------
+    polys : list of shapely.geometry.Polygon
+        A list containing: the input polygon if it didn't cross the dateline, or
+        two polygons otherwise (one on either side of the dateline).
+
+    """
+    x_min, _, x_max, _ = poly.bounds
+
+    # Check dateline crossing
+    if (x_max - x_min > 180.0) or (x_min <= 180.0 <= x_max):
+        dateline = shapely.wkt.loads("LINESTRING( 180.0 -90.0, 180.0 90.0)")
+
+        # build new polygon with all longitudes between 0 and 360
+        x, y = poly.exterior.coords.xy
+        new_x = (k + (k <= 0.0) * 360 for k in x)
+        new_ring = LinearRing(zip(new_x, y))
+
+        # Split input polygon
+        # (https://gis.stackexchange.com/questions/232771/splitting-polygon-by-linestring-in-geodjango_)
+        merged_lines = shapely.ops.linemerge([dateline, new_ring])
+        border_lines = shapely.ops.unary_union(merged_lines)
+        decomp = shapely.ops.polygonize(border_lines)
+
+        polys = list(decomp)
+
+        for polygon_count in range(len(polys)):
+            x, y = polys[polygon_count].exterior.coords.xy
+            # if there are no longitude values above 180, continue
+            if not any(k > 180 for k in x):
+                continue
+
+            # otherwise, wrap longitude values down by 360 degrees
+            x_wrapped_minus_360 = np.asarray(x) - 360
+            polys[polygon_count] = Polygon(zip(x_wrapped_minus_360, y))
+
+    else:
+        # If dateline is not crossed, treat input poly as list
+        polys = [poly]
+
+    return MultiPolygon(polys)

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -37,6 +37,7 @@ from . import __version__ as disp_s1_version
 from ._baselines import _interpolate_data, compute_baselines
 from ._common import DATETIME_FORMAT
 from ._reference import ReferencePoint
+from ._utils import extract_footprint
 from .browse_image import make_browse_image_from_arr
 from .pge_runconfig import AlgorithmParameters, RunConfig
 from .product_info import DISPLACEMENT_PRODUCTS, ProductInfo
@@ -1881,52 +1882,3 @@ def create_compressed_products(
 
     logger.info("Finished creating all compressed SLC products.")
     return results
-
-
-def extract_footprint(raster_path: Filename, simplify_tolerance: float = 0.01) -> str:
-    """Extract a simplified footprint from a raster file.
-
-    This function opens a raster file, extracts its footprint, simplifies it,
-    and returns the a Polygon from the exterior ring as a WKT string.
-
-    Parameters
-    ----------
-    raster_path : str
-        Path to the input raster file.
-    simplify_tolerance : float, optional
-        Tolerance for simplification of the footprint geometry.
-        Default is 0.01.
-
-    Returns
-    -------
-    str
-        WKT string representing the simplified exterior footprint
-        in EPSG:4326 (lat/lon) coordinates.
-
-    Notes
-    -----
-    This function uses GDAL to open the raster and extract the footprint,
-    and Shapely to process the geometry.
-
-    """
-    from os import fspath
-
-    import shapely
-    from osgeo import gdal
-
-    # Extract the footprint as WKT string (don't save)
-    wkt = gdal.Footprint(
-        None,
-        fspath(raster_path),
-        format="WKT",
-        dstSRS="EPSG:4326",
-        simplify=simplify_tolerance,
-    )
-
-    # Convert WKT to Shapely geometry, extract exterior, and convert back to Polygon WKT
-    in_multi = shapely.from_wkt(wkt)
-
-    # This may have holes; get the exterior
-    # Largest polygon should be first in MultiPolygon returned by GDAL
-    footprint = shapely.Polygon(in_multi.geoms[0].exterior)
-    return footprint.wkt

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,11 +6,13 @@ import pytest
 from dolphin import io
 from dolphin.constants import SENTINEL_1_WAVELENGTH
 from dolphin.workflows import UnwrapOptions
+from shapely import from_wkt
 
 from disp_s1._utils import (
     _create_correlation_images,
     _update_snaphu_conncomps,
     _update_spurt_conncomps,
+    check_dateline,
 )
 
 DATA_DIR = Path(__file__).parent / "data"
@@ -154,3 +156,40 @@ def test_update_spurt_conncomps(setup_test_files):
         ts_stem = ts_p.stem  # e.g. "20160708_20170603"
         assert cc_p.stem.startswith(ts_stem)
         assert cc_p.name.endswith(".unw.conncomp.tif"), f"Wrong extension for {cc_p}"
+
+
+def test_check_dateline():
+    from_wkt(
+        "POLYGON ((-111.343848786559 33.167961010325, -111.418794476835"
+        " 32.8232467872268, -110.528205605868 32.6834192684192, -110.510122005303"
+        " 32.8302954024662, -110.475359683262 32.9094439302636, -110.455061760006"
+        " 33.0281538694422, -111.343848786559 33.167961010325))"
+    )
+
+
+def test_dateline_crossing():
+    # Polygon on Ross Ice Shelf (Antarctica)
+    # crossing the dateline
+    polygon_wkt = (
+        "POLYGON((-160.9795 -76.9215,163.3981 -77.0962,"
+        "152.885 -81.8908,-149.3722 -81.6129,-160.9795 -76.9215))"
+    )
+    polygon = from_wkt(polygon_wkt)
+
+    # Check if crossing dateline
+    multipoly = check_dateline(polygon)
+
+    assert len(multipoly.geoms) == 2
+
+    # Test failing frame over alaska
+    polygon = from_wkt(
+        "POLYGON ((-179.695183609472 52.2562453232354,"
+        " 179.99794861982 52.2563010695419,"
+        " 179.158193448683 52.173216336064, 179.172068656626 52.1157703763663,"
+        " 177.933195522318 51.9815738118871, 177.848811722813 52.2543703653295,"
+        " 176.622541622451 52.1084712235005, 176.744861163101 51.7385106813533,"
+        " -179.99953210322 51.7384557700677, -179.57485943579 51.7791857416867,"
+        " -179.695183609472 52.2562453232354))"
+    )
+    multipoly = check_dateline(polygon)
+    assert len(multipoly.geoms) == 2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,7 @@ from disp_s1._utils import (
     _create_correlation_images,
     _update_snaphu_conncomps,
     _update_spurt_conncomps,
-    check_dateline,
+    split_on_antimeridian,
 )
 
 DATA_DIR = Path(__file__).parent / "data"
@@ -159,17 +159,23 @@ def test_update_spurt_conncomps(setup_test_files):
 
 
 def test_check_dateline():
-    from_wkt(
+    """Test a polygon not on the antimeridian."""
+    polygon = from_wkt(
         "POLYGON ((-111.343848786559 33.167961010325, -111.418794476835"
         " 32.8232467872268, -110.528205605868 32.6834192684192, -110.510122005303"
         " 32.8302954024662, -110.475359683262 32.9094439302636, -110.455061760006"
         " 33.0281538694422, -111.343848786559 33.167961010325))"
     )
+    multipoly = split_on_antimeridian(polygon)
+
+    assert len(multipoly.geoms) == 1
+    assert multipoly.geoms[0] == polygon
 
 
 def test_dateline_crossing():
     # Polygon on Ross Ice Shelf (Antarctica)
     # crossing the dateline
+    # Example taken from isce3 unit test
     polygon_wkt = (
         "POLYGON((-160.9795 -76.9215,163.3981 -77.0962,"
         "152.885 -81.8908,-149.3722 -81.6129,-160.9795 -76.9215))"
@@ -177,7 +183,7 @@ def test_dateline_crossing():
     polygon = from_wkt(polygon_wkt)
 
     # Check if crossing dateline
-    multipoly = check_dateline(polygon)
+    multipoly = split_on_antimeridian(polygon)
 
     assert len(multipoly.geoms) == 2
 
@@ -191,5 +197,5 @@ def test_dateline_crossing():
         " -179.99953210322 51.7384557700677, -179.57485943579 51.7791857416867,"
         " -179.695183609472 52.2562453232354))"
     )
-    multipoly = check_dateline(polygon)
+    multipoly = split_on_antimeridian(polygon)
     assert len(multipoly.geoms) == 2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -170,6 +170,7 @@ def test_check_dateline():
 
     assert len(multipoly.geoms) == 1
     assert multipoly.geoms[0] == polygon
+    assert multipoly.area == polygon.area
 
 
 def test_dateline_crossing():
@@ -199,3 +200,6 @@ def test_dateline_crossing():
     )
     multipoly = split_on_antimeridian(polygon)
     assert len(multipoly.geoms) == 2
+    assert (
+        multipoly.area < 0.1 * polygon.area
+    )  # Original failing case had area of hundreds


### PR DESCRIPTION
This PR adds the `split_on_antimeridian` to account for the case where the image straddles the 180 degree meridian. 
The output of `split_on_antimeridian` is a `MultiPolygon`, which has the single `Polygon` in all typical cases, and two `Polygons` on the straddle case.

This PR closes #269 