### PR TITLE
Fix: rescale `timeseries_paths` to radians before running `grow_conncomp_snaphu`

### DIFF
--- a/src/disp_s1/_utils.py
+++ b/src/disp_s1/_utils.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import shutil
 from collections.abc import Sequence
-from math import pi
 from multiprocessing import get_context
 from pathlib import Path
 
@@ -140,7 +139,7 @@ def _create_correlation_images(
         ifg_path, cor_path = args
         logger.debug(f"Estimating correlation for {ifg_path}, writing to {cor_path}")
         disp = io.load_gdal(ifg_path)
-        disp_rad = disp * (-4 * pi) / SENTINEL_1_WAVELENGTH
+        disp_rad = disp * METERS_TO_RADIANS
 
         cor = estimate_correlation_from_phase(disp_rad, window_size=window_size)
         if keep_bits:

--- a/src/disp_s1/main.py
+++ b/src/disp_s1/main.py
@@ -26,11 +26,10 @@ from disp_s1.pge_runconfig import AlgorithmParameters, RunConfig
 
 from ._reference import ReferencePoint, read_reference_point
 from ._utils import (
-    METERS_TO_RADIANS,
+    _convert_meters_to_radians,
     _create_correlation_images,
     _update_snaphu_conncomps,
     _update_spurt_conncomps,
-    create_scaled_vrt,
 )
 
 logger = logging.getLogger(__name__)
@@ -207,9 +206,8 @@ def create_products(
     # Check and update connected components paths
     assert out_paths.conncomp_paths is not None
     if set(group_by_date(out_paths.conncomp_paths).keys()) != disp_date_keys:
-        timeseries_rad_paths = create_scaled_vrt(
-            out_paths.timeseries_paths, scale_factor=METERS_TO_RADIANS
-        )
+        logger.info("Converting timeseries rasters to radians")
+        timeseries_rad_paths = _convert_meters_to_radians(out_paths.timeseries_paths)
         method = cfg.unwrap_options.unwrap_method
         if method in ("snaphu", "phass", "whirlwind"):
             row_looks, col_looks = cfg.phase_linking.half_window.to_looks()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,10 +8,10 @@ from shapely import from_wkt
 
 from disp_s1._utils import (
     METERS_TO_RADIANS,
+    _convert_meters_to_radians,
     _create_correlation_images,
     _update_snaphu_conncomps,
     _update_spurt_conncomps,
-    create_scaled_vrt,
     split_on_antimeridian,
 )
 
@@ -57,21 +57,17 @@ def test_create_correlations(ts_filenames):
         assert 0.2 < data.mean() < 0.8
 
 
-def test_convert_meters_to_radians_vrt(ts_filenames):
-    """Test that convert_meters_to_radians_vrt correctly creates scaled VRT files."""
-    # Call the function to test
-    unw_vrt_paths = create_scaled_vrt(ts_filenames)
+def test_convert_meters_to_radians(ts_filenames):
+    """Test that _convert_meters_to_radians correctly creates scaled files."""
+    unw_scaled_paths = _convert_meters_to_radians(ts_filenames)
 
-    # Verify the output path
-    assert len(unw_vrt_paths) == 3
-    assert unw_vrt_paths[0] == ts_filenames[0].with_suffix(".scaled.vrt")
-    assert unw_vrt_paths[0].exists()
-
-    # Verify the VRT content
-    expected_scale_factor = METERS_TO_RADIANS
+    assert len(unw_scaled_paths) == 3
+    assert unw_scaled_paths[0] == ts_filenames[0].with_suffix(".radians.tif")
+    assert unw_scaled_paths[0].exists()
 
     # Read the data through the VRT to verify the scaling
-    for unw_p, ts_p in zip(unw_vrt_paths, ts_filenames, strict=True):
+    expected_scale_factor = METERS_TO_RADIANS
+    for unw_p, ts_p in zip(unw_scaled_paths, ts_filenames, strict=True):
         scaled_data = io.load_gdal(unw_p)
         disp_meters = io.load_gdal(ts_p)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,14 +1,13 @@
-from math import pi
 from pathlib import Path
 
 import numpy as np
 import pytest
 from dolphin import io
-from dolphin.constants import SENTINEL_1_WAVELENGTH
 from dolphin.workflows import UnwrapOptions
 from shapely import from_wkt
 
 from disp_s1._utils import (
+    METERS_TO_RADIANS,
     _create_correlation_images,
     _update_snaphu_conncomps,
     _update_spurt_conncomps,
@@ -29,7 +28,7 @@ def ts_filenames(tmp_path) -> list[Path]:
     ramp_rad = (np.arange(0, 512).reshape(512, 1) / 10) * np.ones((1, 512))
     ramp_rad += np.random.randn(*ramp_rad.shape)
 
-    rad_to_meters = SENTINEL_1_WAVELENGTH / (-4 * pi)
+    rad_to_meters = 1 / METERS_TO_RADIANS
     ramp_meters = ramp_rad * rad_to_meters
 
     for i in range(3):
@@ -69,7 +68,7 @@ def test_convert_meters_to_radians_vrt(ts_filenames):
     assert unw_vrt_paths[0].exists()
 
     # Verify the VRT content
-    expected_scale_factor = (-4 * pi) / SENTINEL_1_WAVELENGTH
+    expected_scale_factor = METERS_TO_RADIANS
 
     # Read the data through the VRT to verify the scaling
     for unw_p, ts_p in zip(unw_vrt_paths, ts_filenames, strict=True):


### PR DESCRIPTION
The correlation was fixed in #217 , but the meters version of the unwrapped outputs are still passed to SNAPHU.

Adds ~~`create_scaled_vrt` to create virtual files~~ `_convert_meters_to_radians` with a scale factor of $-4 \pi / \lambda$ to convert meters to radians.

(VRTs were avoided since we want write into them with rasterio, so the dolphin regrow function failed)