### PR TITLE
Remove `conncomp==0` condition from filtering and `recommended_mask`. Default `spatial_wavelength_cutoff = 60 km`

### DIFF
--- a/configs/algorithm_parameters_historical_20250213.yaml
+++ b/configs/algorithm_parameters_historical_20250213.yaml
@@ -323,10 +323,14 @@ recommended_temporal_coherence_threshold: 0.6
 #   temporal coherence below `recommended_temporal_coherence_threshold` are masked.
 #   Type: number.
 recommended_similarity_threshold: 0.5
+# When creating `recommended_mask`, use the `connected_component_label`"
+#   layer to hide pixels whose label == 0.
+#   Type: boolean.
+recommended_use_conncomp: false
 # Spatial wavelength cutoff (in meters) for the spatial filter. Used to create the short
 #   wavelength displacement layer.
 #   Type: number.
-spatial_wavelength_cutoff: 25000.0
+spatial_wavelength_cutoff: 60000.0
 # `vmin, vmax` matplotlib arguments (in meters) passed to browse image creator.
 #   Type: array.
 browse_image_vmin_vmax:

--- a/configs/algorithm_parameters_historical_20250213.yaml
+++ b/configs/algorithm_parameters_historical_20250213.yaml
@@ -318,11 +318,11 @@ subdataset: /data/VV
 # When creating `recommended_mask`, pixels with temporal coherence below this threshold and
 #   with similarity below `recommended_similarity_threshold` are masked.
 #   Type: number.
-recommended_temporal_coherence_threshold: 0.6
+recommended_temporal_coherence_threshold: 0.5
 # When creating `recommended_mask`, pixels with similarity below this threshold and with
 #   temporal coherence below `recommended_temporal_coherence_threshold` are masked.
 #   Type: number.
-recommended_similarity_threshold: 0.5
+recommended_similarity_threshold: 0.30
 # When creating `recommended_mask`, use the `connected_component_label`"
 #   layer to hide pixels whose label == 0.
 #   Type: boolean.
@@ -330,7 +330,7 @@ recommended_use_conncomp: false
 # Spatial wavelength cutoff (in meters) for the spatial filter. Used to create the short
 #   wavelength displacement layer.
 #   Type: number.
-spatial_wavelength_cutoff: 60000.0
+spatial_wavelength_cutoff: 40000.0
 # `vmin, vmax` matplotlib arguments (in meters) passed to browse image creator.
 #   Type: array.
 browse_image_vmin_vmax:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -68,10 +68,10 @@ RUN micromamba install --yes --channel conda-forge -n base -f /tmp/specfile.txt 
 # Activate, otherwise python will not be found
 # https://github.com/mamba-org/micromamba-docker#running-commands-in-dockerfile-within-the-conda-environment
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
-RUN pip install git+https://github.com/isce-framework/spurt@v0.1.0
+RUN pip install git+https://github.com/isce-framework/spurt@v0.1.1
 # --no-deps because they are installed with conda
 RUN pip install --no-deps git+https://github.com/opera-adt/opera-utils@v0.16.0
-RUN pip install --no-deps git+https://github.com/isce-framework/dolphin@v0.36.1
+RUN pip install --no-deps git+https://github.com/isce-framework/dolphin@v0.37.0
 
 COPY --chown=$MAMBA_USER:$MAMBA_USER . .
 RUN python -m pip install --no-deps .

--- a/scripts/align_to_common_reference_date.py
+++ b/scripts/align_to_common_reference_date.py
@@ -311,6 +311,22 @@ def _parse_datetimes(
     return reference_times, secondary_times, generation_times
 
 
+def _get_last_file_per_ministack(
+    opera_file_list: Sequence[Path | str],
+) -> list[Path | str]:
+    def _get_generation_time(fname):
+        return _parse_datetimes([fname])[2][0]
+
+    last_per_ministack = []
+    for d, cur_groupby in itertools.groupby(
+        sorted(opera_file_list), key=_get_generation_time
+    ):
+        # cur_groupby is an iterable of all matching
+        # Get the first one
+        last_per_ministack.append(list(cur_groupby)[-1])
+    return last_per_ministack
+
+
 def _pick_reference_point(
     output_dir: Path,
     temp_coh_files: list[Path],

--- a/src/disp_s1/pge_runconfig.py
+++ b/src/disp_s1/pge_runconfig.py
@@ -209,6 +209,13 @@ class AlgorithmParameters(YamlModel):
             " `recommended_temporal_coherence_threshold` are masked."
         ),
     )
+    recommended_use_conncomp: bool = Field(
+        False,
+        description=(
+            "When creating `recommended_mask`, use the `connected_component_label`"
+            " layer to hide pixels whose label == 0."
+        ),
+    )
     # Extra product creation options
     spatial_wavelength_cutoff: float = Field(
         25_000,


### PR DESCRIPTION
- Adds algorithm parameter `recommended_use_conncomp`. Default is `False`, so the connected component labels are *not* used in the `recommended_mask`.
- Increases `spatial_wavelength_cutoff` to 30 km (`sigma = 353` pixels. Previous cutoff of `filtering._compute_filter_sigma(25e3, 30, .5)*0.707` was `110` pixels)
- Drops (temporal coherence, similarity) threshold from (0.6, 0.5) to (0.5, 0.3) to show more pixels.