### PR TITLE
Add call to `dolphin.workflows.corrections.run` for ionospheric correction refactor

### DIFF
--- a/.github/workflows/test-build-push.yml
+++ b/.github/workflows/test-build-push.yml
@@ -19,7 +19,7 @@ jobs:
           - label: Latest
             tag: "main"
           - label: Last Release
-            tag: v0.35.0
+            tag: v0.38.0
 
       fail-fast: true
     name: ${{ matrix.os }} • ${{ matrix.dolphin.label }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,7 +71,7 @@ ARG MAMBA_DOCKERFILE_ACTIVATE=1
 RUN pip install git+https://github.com/isce-framework/spurt@v0.1.1
 # --no-deps because they are installed with conda
 RUN pip install --no-deps git+https://github.com/opera-adt/opera-utils@v0.16.0
-RUN pip install --no-deps git+https://github.com/isce-framework/dolphin@v0.37.0
+RUN pip install --no-deps git+https://github.com/isce-framework/dolphin@v0.38.0
 
 COPY --chown=$MAMBA_USER:$MAMBA_USER . .
 RUN python -m pip install --no-deps .

--- a/src/disp_s1/main.py
+++ b/src/disp_s1/main.py
@@ -14,6 +14,7 @@ from dolphin._log import log_runtime, setup_logging
 from dolphin.unwrap._utils import create_combined_mask
 from dolphin.utils import DummyProcessPoolExecutor, full_suffix, get_max_memory_usage
 from dolphin.workflows.config import DisplacementWorkflow
+from dolphin.workflows.corrections import run as run_corrections
 from dolphin.workflows.displacement import OutputPaths
 from dolphin.workflows.displacement import run as run_displacement
 from opera_utils import get_dates, group_by_burst, group_by_date
@@ -97,6 +98,23 @@ def run(
 
     # Run dolphin's displacement workflow
     out_paths = run_displacement(cfg=cfg, debug=debug)
+
+    # Run dolphin's corrections workflow
+    assert out_paths.timeseries_paths is not None
+    out_corrections_paths = run_corrections(
+        cfg=cfg,
+        correction_options=cfg.correction_options,
+        timeseries_paths=out_paths.timeseries_paths,
+        out_dir=cfg.work_directory,
+        debug=debug,
+    )
+    # Update the output paths with the corrections to only pass one object
+    setattr(
+        out_paths,
+        "ionospheric_corrections",
+        out_corrections_paths.ionospheric_corrections,
+    )
+
     create_products(
         out_paths=out_paths,
         cfg=cfg,


### PR DESCRIPTION
Using the refactor https://github.com/isce-framework/dolphin/pull/531 , we need to call the ionospheric corrections separately here.

Waiting on merge and new release to pin lower version bounds.