### PR TITLE
Fix online PS weighting to normalize by `.min()`

### DIFF
--- a/src/disp_s1/main.py
+++ b/src/disp_s1/main.py
@@ -23,7 +23,7 @@ from opera_utils.geometry import get_incidence_angles
 from disp_s1 import __version__, product
 from disp_s1._masking import create_layover_shadow_masks, create_mask_from_distance
 from disp_s1._ps import precompute_ps
-from disp_s1.pge_runconfig import AlgorithmParameters, RunConfig, StaticLayersRunConfig
+from disp_s1.pge_runconfig import AlgorithmParameters, RunConfig
 
 from ._reference import ReferencePoint, read_reference_point
 from ._utils import (
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 @log_runtime
 def run(
     cfg: DisplacementWorkflow,
-    pge_runconfig: RunConfig | StaticLayersRunConfig,
+    pge_runconfig: RunConfig,
     debug: bool = False,
 ) -> None:
     """Run the displacement workflow on a stack of SLCs.

--- a/tests/test_ps.py
+++ b/tests/test_ps.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+from disp_s1._ps import WeightScheme, _get_weighting
+
+
+def test_get_weighting():
+    expected_ns = [
+        [1],
+        [1, 2],
+        [1, 2, 3],
+        [1, 2, 3, 4],
+        [1, 2, 3, 4, 7],
+        [1, 2, 3, 4, 7, 12],
+    ]
+    for num_comp, expected_N in enumerate(expected_ns):
+        N = _get_weighting(
+            num_compressed_slc_files=num_comp,
+            weight_scheme=WeightScheme.EXPONENTIAL,
+            num_slc=15,
+        )
+        assert np.allclose(N, expected_N)


### PR DESCRIPTION
Normalizing by `.max()` meant older ones were rounded down to zero, newer were rounded to 1.

Note that this hasn't drastically affected end results since this is also a valid strategy (it's the same as `WeightScheme.EQUAL`, only accounting for the past two mini-stacks).