### PR TITLE
Undo output name change from #309

### DIFF
--- a/scripts/rename_output.py
+++ b/scripts/rename_output.py
@@ -237,7 +237,7 @@ def _create_disp_s1_compressed_filename(
         raise ValueError(f"{input_file} is not a Compressed SLC")
 
     try:
-        ref_date, start_date, stop_date = get_dates(input_file)[:3]
+        ref_datetime, start_datetime, stop_datetime = get_dates(input_file)[:3]
         burst_id = get_burst_id(input_file)
     except Exception as e:
         fmt = "<base-date>_<start-date>_<end-date>_<burst_id>"
@@ -247,10 +247,11 @@ def _create_disp_s1_compressed_filename(
         prod_time = datetime.datetime.now()
     prod_time_str = _format_dt(prod_time)
 
+    datefmt = "%Y%m%d"
     return (
         f"OPERA_L2_COMPRESSED-CSLC-S1_{burst_id}_"
-        f"{ref_date}T000000Z_{start_date}T000000Z_"
-        f"{stop_date}T000000Z_{prod_time_str}_"
+        f"{ref_datetime.strftime(datefmt)}T000000Z_{start_datetime.strftime(datefmt)}T000000Z_"
+        f"{stop_datetime.strftime(datefmt)}T000000Z_{prod_time_str}_"
         "VV_v1.0.h5"
     )
 

--- a/scripts/rename_output.py
+++ b/scripts/rename_output.py
@@ -248,8 +248,9 @@ def _create_disp_s1_compressed_filename(
     prod_time_str = _format_dt(prod_time)
 
     datefmt = "%Y%m%d"
+    burst_id_caps = burst_id.replace("_", "-").upper()
     return (
-        f"OPERA_L2_COMPRESSED-CSLC-S1_{burst_id}_"
+        f"OPERA_L2_COMPRESSED-CSLC-S1_{burst_id_caps}_"
         f"{ref_datetime.strftime(datefmt)}T000000Z_{start_datetime.strftime(datefmt)}T000000Z_"
         f"{stop_datetime.strftime(datefmt)}T000000Z_{prod_time_str}_"
         "VV_v1.0.h5"

--- a/scripts/rename_output.py
+++ b/scripts/rename_output.py
@@ -267,7 +267,7 @@ def _create_disp_s1_compressed_filename(
 )
 @click.option("--dry-run", is_flag=True)
 def main(input_files, output_dir, version, dry_run):
-    """Rename a DISP-S1 NetCDF file to an official OPERA name."""
+    """Rename a DISP-S1 NetCDF/Compressed HDF5 file to an official OPERA name."""
     for input_file in input_files:
         rename_disp_s1_file(
             input_file=input_file,

--- a/scripts/rename_output.py
+++ b/scripts/rename_output.py
@@ -20,6 +20,7 @@ from typing import Optional
 
 import click
 import h5py
+from opera_utils import get_burst_id, get_dates
 
 
 def _read_disp_s1_metadata(nc_file: Path) -> dict:
@@ -174,6 +175,18 @@ def rename_disp_s1_file(
         The path to the newly renamed file.
 
     """
+    if Path(input_file).stem.lower().startswith("compressed"):
+        new_filename = _create_disp_s1_compressed_filename(input_file=input_file)
+    else:
+        new_filename = _create_disp_s1_filename(input_file=input_file, version=version)
+    return _rename(input_file, new_filename, output_dir=output_dir, dry_run=dry_run)
+
+
+def _create_disp_s1_filename(
+    input_file: Path,
+    version: str = "0.10",
+) -> str:
+    """Create the DISP-S1 NetCDF file to the OPERA naming convention."""
     meta = _read_disp_s1_metadata(input_file)
 
     frame_id = meta["frame_id"]
@@ -191,8 +204,15 @@ def rename_disp_s1_file(
         version=version,
     )
 
-    new_filename = f"{core_name}.nc"
+    return f"{core_name}.nc"
 
+
+def _rename(
+    input_file: Path,
+    new_filename: str,
+    output_dir: Optional[Path] = None,
+    dry_run: bool = False,
+) -> Path:
     # If no output directory was provided, use the same directory as the input file
     if output_dir is None:
         output_dir = input_file.parent
@@ -206,6 +226,33 @@ def rename_disp_s1_file(
         click.echo(f"Renamed {input_file} to {new_file_path}")
 
     return new_file_path
+
+
+def _create_disp_s1_compressed_filename(
+    input_file: Path,
+    prod_time: datetime.datetime | None = None,
+) -> str:
+    """Create the compressed SLC filename folloing OPERA naming convention."""
+    if not Path(input_file).stem.lower().startswith("compressed"):
+        raise ValueError(f"{input_file} is not a Compressed SLC")
+
+    try:
+        ref_date, start_date, stop_date = get_dates(input_file)[:3]
+        burst_id = get_burst_id(input_file)
+    except Exception as e:
+        fmt = "<base-date>_<start-date>_<end-date>_<burst_id>"
+        raise ValueError(f"{input_file} name does not match {fmt}") from e
+
+    if prod_time is None:
+        prod_time = datetime.datetime.now()
+    prod_time_str = _format_dt(prod_time)
+
+    return (
+        f"OPERA_L2_COMPRESSED-CSLC-S1_{burst_id}_"
+        f"{ref_date}T000000Z_{start_date}T000000Z_"
+        f"{stop_date}T000000Z_{prod_time_str}_"
+        "VV_v1.0.h5"
+    )
 
 
 @click.command()

--- a/src/disp_s1/product.py
+++ b/src/disp_s1/product.py
@@ -76,7 +76,7 @@ HDF5_OPTS["chunks"] = tuple(CHUNK_SHAPE)  # type: ignore
 # https://github.com/corteva/rioxarray/blob/5783693895b4b055909c5758a72a5d40a365ef11/rioxarray/rioxarray.py#L34 # noqa
 GRID_MAPPING_DSET = "spatial_ref"
 
-COMPRESSED_SLC_TEMPLATE = "OPERA_L2_COMPRESSED-CSLC-S1_{burst_id}-{date_str}.h5"
+COMPRESSED_SLC_TEMPLATE = "compressed_{burst_id}_{date_str}.h5"
 
 
 def create_output_product(


### PR DESCRIPTION
We don't want to make SDS update the PGE script.

But, I added this logic to rename to the existing `rename_outputs.py`

So we can rename an output disp:
```
$ python ~/repos/disp-s1/scripts/rename_output.py 20170107_20170612.nc
Renamed 20170107_20170612.nc to OPERA_L3_DISP-S1_IW_F33039_VV_20170107T043033Z_20170612T043036Z_v0.10_20250520T053436Z.nc
```

or a compressed file
```
$ python ~/repos/disp-s1/scripts/rename_output.py compressed_t124_264305_iw1_20161226_20160711_20161226.h5
Renamed compressed_t124_264305_iw2_20161226_20160711_20161226.h5 to OPERA_L2_COMPRESSED-CSLC-S1_T124-264305-IW2_20161226T000000Z_20160711T000000Z_20161226T000000Z_20250520T135001Z_VV_v1.0.h5
```

