### PR TITLE
Add in the interpolation_cor_threshold when creating the recommended mask

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,7 +71,7 @@ ARG MAMBA_DOCKERFILE_ACTIVATE=1
 RUN pip install git+https://github.com/isce-framework/spurt@v0.1.1
 # --no-deps because they are installed with conda
 RUN pip install --no-deps git+https://github.com/opera-adt/opera-utils@v0.23.0
-RUN pip install --no-deps git+https://github.com/isce-framework/dolphin@v0.39.0
+RUN pip install --no-deps git+https://github.com/isce-framework/dolphin@v0.40.0
 
 COPY --chown=$MAMBA_USER:$MAMBA_USER . .
 RUN python -m pip install --no-deps .


### PR DESCRIPTION
With https://github.com/isce-framework/dolphin/pull/612 , the pixels with very low `estimated_phase_quality` (aka sliding window correlation) are masking and interpolated over. Thus, they should not be recommended