### PR TITLE
Product bounds fix, and added input checks f

### DIFF
--- a/.github/workflows/test-build-push.yml
+++ b/.github/workflows/test-build-push.yml
@@ -39,7 +39,7 @@ jobs:
           password: ${{ secrets.EARTHDATA_PASSWORD }}
 
       - name: Setup environment
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v3
         with:
           environment-file: conda-env.yml
           environment-name: disp-s1-env

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -25,6 +25,7 @@ dependencies:
   - isce3-cpu>=0.16.0 # For baseline
   - tophu
   # - cxx-compiler # for whirlwind
-  - dolphin>=0.35.0
+  - dolphin>=0.42.7
+  - opera-utils>=0.25.7  # dolphin>=0.42.7 needs is_remote_url (added in 0.25.7)
   - pip:
     - spurt>=0.1.0

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -25,7 +25,9 @@ dependencies:
   - isce3-cpu>=0.16.0 # For baseline
   - tophu
   # - cxx-compiler # for whirlwind
-  - dolphin>=0.42.7
-  - opera-utils>=0.25.7  # dolphin>=0.42.7 needs is_remote_url (added in 0.25.7)
   - pip:
+    # dolphin/opera-utils installed via pip: conda-forge lags PyPI and doesn't
+    # yet have dolphin>=0.42.7 / opera-utils>=0.25.7.
+    - dolphin>=0.42.7
+    - opera-utils>=0.25.7  # dolphin>=0.42.7 needs is_remote_url (added in 0.25.7)
     - spurt>=0.1.0

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -25,6 +25,7 @@ dependencies:
   - isce3-cpu>=0.16.0 # For baseline
   - tophu
   # - cxx-compiler # for whirlwind
+  - rich  # opera_utils.missing_data imports this but doesn't declare it as a dep
   - pip:
     # dolphin/opera-utils installed via pip: conda-forge lags PyPI and doesn't
     # yet have dolphin>=0.42.7 / opera-utils>=0.25.7.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+# Local development / smoke-testing of the disp-s1 image.
+#
+#   docker compose build
+#   docker compose run --rm disp_s1                       # `disp-s1 --help`
+#   docker compose run --rm disp_s1 bash                  # interactive shell
+#   docker compose run --rm disp_s1 \
+#       disp-s1 run /work/runconfig.yaml                  # run a PGE runconfig
+#
+# Mounts ./src/disp_s1 over the installed package so code edits are picked up
+# without rebuilding (the image installs disp-s1 non-editable), ./configs for the
+# runconfig/algorithm-parameter YAMLs, and ./data as the scratch/output area
+# (mirrors `-v $PWD:/work` from docker/build-docker-image.sh).
+# Credentials are mounted read-only: ~/.aws for S3 (and the ASF role), ~/.netrc
+# for Earthdata (machine urs.earthdata.nasa.gov) ancillary downloads.
+services:
+  disp_s1:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    image: opera-adt/disp-s1:latest
+    container_name: disp_s1
+    # Run as the host user so files written to the mounted ./data are owned by
+    # you, not root (mirrors `--user $(id -u):$(id -g)` in the build script).
+    user: "${UID:-1000}:${GID:-1000}"
+    volumes:
+      # Live code: overlay the source tree onto the installed package (py3.13).
+      - ./src/disp_s1:/opt/conda/lib/python3.13/site-packages/disp_s1
+      - ./configs:/work/configs
+      - ./data:/work
+      - ${HOME}/.aws:/root/.aws:ro
+      - ${HOME}/.netrc:/root/.netrc:ro
+    environment:
+      - AWS_PROFILE=${AWS_PROFILE:-saml-pub}
+      - AWS_DEFAULT_REGION=us-west-2
+      - PYTHONUNBUFFERED=1
+      # ASF temporary S3 creds for reading CSLC/ancillary buckets directly
+      # (normally injected by the submitter on AWS; set here for local testing).
+      - ASF_ACCESS_KEY_ID=${ASF_ACCESS_KEY_ID:-}
+      - ASF_SECRET_ACCESS_KEY=${ASF_SECRET_ACCESS_KEY:-}
+      - ASF_SESSION_TOKEN=${ASF_SESSION_TOKEN:-}
+    working_dir: /work
+    stdin_open: true
+    tty: true

--- a/scripts/disp_s1_process.py
+++ b/scripts/disp_s1_process.py
@@ -1,5 +1,4 @@
-"""
-Standalone DISP-S1 processing pipeline (Sentinel-1), driven from the CLI.
+r"""Standalone DISP-S1 processing pipeline (Sentinel-1), driven from the CLI.
 
 Given a directory of CSLC/GSLC bursts, this runs the full local pipeline for an
 arbitrary site/track/frame:
@@ -14,7 +13,7 @@ All site-specific values (input dir, work dir, frame id, spatial extent,
 ministack size, ...) are command-line arguments; nothing is hardcoded to a
 particular acquisition. Run ``python disp_s1_process.py --help`` for options.
 
-Example
+Example:
 -------
     python disp_s1_process.py \\
         --cslc-dir /path/to/gslcs/t161_343970_iw2 \\
@@ -22,39 +21,33 @@ Example
         --frame-id 42997 \\
         --extent "4.3561,51.0951 : 4.373,51.1031" \\
         --ministack-size 15 --buffer 500
+
 """
 
 from __future__ import annotations
 
 import argparse
 import contextlib
-import io
 import logging
 import os
 import re
 import shutil
 import sys
 import time
-import warnings
 from collections.abc import Sequence
 from dataclasses import asdict
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from types import SimpleNamespace
 
 import h5py
 import numpy as np
 import pandas as pd
 import rasterio
-import rioxarray  # noqa: F401
 import xarray as xr
 import zarr
-from pyproj import CRS, Transformer
-from rasterio.windows import from_bounds
-
 from dolphin._log import setup_logging
 from dolphin.stack import CompressedSlcPlan
-from dolphin.timeseries import estimate_velocity, datetime_to_float
+from dolphin.timeseries import datetime_to_float, estimate_velocity
 from dolphin.utils import get_max_memory_usage
 from dolphin.workflows import PreprocessOptions, SnaphuOptions
 from dolphin.workflows.config import (
@@ -70,9 +63,11 @@ from dolphin.workflows.config import (
 )
 from dolphin.workflows.corrections import CorrectionOptions
 from dolphin.workflows.displacement import run as run_displacement
+from opera_utils import OPERA_DATASET_NAME, group_by_burst, group_by_date
+from pyproj import CRS, Transformer
+from rasterio.windows import from_bounds
 
 from disp_s1 import __version__
-from disp_s1 import main as disp_s1_main
 from disp_s1._masking import create_mask_from_distance
 from disp_s1._ps import precompute_ps
 from disp_s1.main import (
@@ -92,31 +87,15 @@ from disp_s1.pge_runconfig import (
     StaticAncillaryFileGroup,
 )
 
-from opera_utils import OPERA_DATASET_NAME, group_by_burst
-from opera_utils.disp._enums import (
-    CorrectionDataset,
-    DisplacementDataset,
-    QualityDataset,
-    ReferenceMethod,
-)
-from opera_utils.disp._netcdf import create_virtual_stack
-from opera_utils.disp._rebase import NaNPolicy, create_rebased_displacement
-from opera_utils.disp._reference import _get_reference_row_col, get_reference_values
-from opera_utils.disp._reformat import (
-    _get_zarr_encoding,
-    _get_transform,
-    _to_shard_dict,
-    _write_rebased_stack,
-    combine_quality_masks,
-)
-from opera_utils.disp._utils import _clamp_chunk_dict, _get_netcdf_encoding, round_mantissa
-from opera_utils import group_by_date
+# NOTE: the whole `opera_utils.disp` subpackage (and rioxarray) is imported lazily
+# inside reformat_stack_custom so the `process` stage can run in environments that
+# lack the reformat toolchain (e.g. disp-patch-env without rioxarray).
 
 # ── DEFAULTS ──────────────────────────────────────────────────────────────────
 # Site-specific values now come from the CLI (see build_parser / main).
-DEFAULT_MS_SIZE = 15        # acquisitions per ministack
-DEFAULT_BUFFER = 500.0      # metres of padding around the requested extent
-DEFAULT_MAX_COMP = 5        # compressed SLCs carried forward per burst (historical)
+DEFAULT_MS_SIZE = 15  # acquisitions per ministack
+DEFAULT_BUFFER = 500.0  # metres of padding around the requested extent
+DEFAULT_MAX_COMP = 5  # compressed SLCs carried forward per burst (historical)
 DEFAULT_FORWARD_WINDOW = 5  # real SLCs per forward run: n-4, n-3, n-2, n-1, n
 DEFAULT_GSLC_GLOB = "t*.h5"  # pattern matching (G)SLC HDF5 files, any burst id
 
@@ -124,6 +103,7 @@ DEFAULT_GSLC_GLOB = "t*.h5"  # pattern matching (G)SLC HDF5 files, any burst id
 os.environ.setdefault("XLA_PYTHON_CLIENT_MEM_FRACTION", "0.1")
 
 # ── HELPERS ───────────────────────────────────────────────────────────────────
+
 
 def make_cfg(
     cslc_files: list[Path],
@@ -152,7 +132,7 @@ def make_cfg(
             use_evd=False,
             beta=0.0,
             zero_correlation_threshold=0.0,
-            shp_method='glrt',
+            shp_method="glrt",
             shp_alpha=0.001,
             mask_input_ps=False,
             baseline_lag=None,
@@ -181,7 +161,11 @@ def make_cfg(
                 single_tile_reoptimize=False,
             ),
         ),
-        worker_settings={"gpu_enabled": gpu, "threads_per_worker": 8, "n_parallel_bursts": 1},
+        worker_settings={
+            "gpu_enabled": gpu,
+            "threads_per_worker": 8,
+            "n_parallel_bursts": 1,
+        },
     )
 
 
@@ -276,7 +260,9 @@ def _ensure_correction_options(cfg):
         cfg.correction_options = CorrectionOptions()
 
 
-def run_no_corrections(cfg: DisplacementWorkflow, pge_runconfig: RunConfig, debug: bool = False):
+def run_no_corrections(
+    cfg: DisplacementWorkflow, pge_runconfig: RunConfig, debug: bool = False
+):
     """Run disp_s1 without the corrections workflow (no geometry files available)."""
     cfg.work_directory.mkdir(exist_ok=True, parents=True)
     if cfg.log_file is None:
@@ -322,6 +308,7 @@ def run_no_corrections(cfg: DisplacementWorkflow, pge_runconfig: RunConfig, debu
 
         if is_forward:
             from dolphin.timeseries import _redo_reference
+
             final_ts_paths, final_residual_paths = _redo_reference(
                 out_paths.timeseries_paths,
                 out_paths.timeseries_residual_paths,
@@ -377,7 +364,7 @@ def reformat_stack_custom(
     apply_ionospheric_corrections: bool = False,
     quality_datasets: Sequence[str] | None = ["recommended_mask"],
     quality_thresholds: Sequence[float] | None = [0.5],
-    reference_method: ReferenceMethod = ReferenceMethod.HIGH_COHERENCE,
+    reference_method: "ReferenceMethod | None" = None,
     reference_row: int | None = None,
     reference_col: int | None = None,
     reference_lon: float | None = None,
@@ -388,6 +375,26 @@ def reformat_stack_custom(
     do_round: bool = True,
 ) -> None:
     """Reformat per-ministack .nc outputs into a unified zarr/netcdf stack."""
+    import rioxarray  # noqa: F401  (registers the .rio xarray accessor)
+    from opera_utils.disp._enums import (
+        CorrectionDataset,
+        DisplacementDataset,
+        QualityDataset,
+        ReferenceMethod,
+    )
+    from opera_utils.disp._netcdf import create_virtual_stack
+    from opera_utils.disp._reference import _get_reference_row_col
+    from opera_utils.disp._reformat import (
+        _get_transform,
+        _get_zarr_encoding,
+        _to_shard_dict,
+        _write_rebased_stack,
+    )
+    from opera_utils.disp._utils import _get_netcdf_encoding, round_mantissa
+
+    if reference_method is None:
+        reference_method = ReferenceMethod.HIGH_COHERENCE
+
     start_time = time.time()
 
     if Path(output_name).suffix == ".nc":
@@ -406,7 +413,7 @@ def reformat_stack_custom(
     if apply_ionospheric_corrections:
         corrections.append(CorrectionDataset.IONOSPHERIC_DELAY)
 
-    out_chunk_dict = dict(zip(["time", "y", "x"], out_chunks))
+    dict(zip(["time", "y", "x"], out_chunks))
     out_shard_dict = _to_shard_dict(out_chunks, shard_factors)
 
     input_files = sorted(input_files, key=lambda p: _parse_dates_from_filename(p))
@@ -415,7 +422,11 @@ def reformat_stack_custom(
         [_parse_dates_from_filename(p)[0].replace(tzinfo=None) for p in input_files]
     )
 
-    process_chunk_dict = {"time": 1, "y": process_chunk_size[0], "x": process_chunk_size[1]}
+    process_chunk_dict = {
+        "time": 1,
+        "y": process_chunk_size[0],
+        "x": process_chunk_size[1],
+    }
 
     ds = xr.open_mfdataset(input_files, engine="h5netcdf", chunks=process_chunk_dict)
     ds_corrections = xr.open_mfdataset(
@@ -435,24 +446,33 @@ def reformat_stack_custom(
 
     if out_format == "zarr":
         encoding = _get_zarr_encoding(ds_minimal, out_chunks, add_coords=True)
-        ds_minimal.chunk(out_shard_dict).to_zarr(output_name, encoding=encoding, mode="w", consolidated=False)
+        ds_minimal.chunk(out_shard_dict).to_zarr(
+            output_name, encoding=encoding, mode="w", consolidated=False
+        )
     else:
         encoding = _get_netcdf_encoding(ds_minimal, out_chunks)
-        ds_minimal.to_netcdf(output_name, engine="h5netcdf", encoding=encoding, mode="w")
+        ds_minimal.to_netcdf(
+            output_name, engine="h5netcdf", encoding=encoding, mode="w"
+        )
     print(f"Wrote minimal dataset in {time.time() - start_time:.1f}s")
 
     QUALITY_DATASETS = list(QualityDataset)
     remaining_dsets = [
-        str(d) for d in QUALITY_DATASETS
+        str(d)
+        for d in QUALITY_DATASETS
         if d != "water_mask" and str(d) not in drop_vars
     ]
-    ds_remaining = ds[remaining_dsets].chunk({
-        "time": out_shard_dict["time"],
-        "y": process_chunk_dict["y"],
-        "x": process_chunk_dict["x"],
-    })
+    ds_remaining = ds[remaining_dsets].chunk(
+        {
+            "time": out_shard_dict["time"],
+            "y": process_chunk_dict["y"],
+            "x": process_chunk_dict["x"],
+        }
+    )
     da_temp_coh = ds.temporal_coherence[::15]
-    avg_coherence = da_temp_coh.shape[0] / (1.0 / da_temp_coh).sum(dim="time", skipna=False, min_count=1)
+    avg_coherence = da_temp_coh.shape[0] / (1.0 / da_temp_coh).sum(
+        dim="time", skipna=False, min_count=1
+    )
     ds_remaining["average_temporal_coherence"] = xr.DataArray(
         avg_coherence, dims=("y", "x"), coords={"y": ds.y, "x": ds.x}
     )
@@ -464,11 +484,19 @@ def reformat_stack_custom(
     print(f"Writing remaining variables: {list(ds_remaining.data_vars)}")
     if out_format == "zarr":
         encoding = _get_zarr_encoding(ds_remaining, out_chunks)
-        ds_remaining.to_zarr(output_name, encoding=encoding, mode="a", consolidated=False)
+        ds_remaining.to_zarr(
+            output_name, encoding=encoding, mode="a", consolidated=False
+        )
     else:
-        create_virtual_stack(input_files=input_files, output=output_name, dataset_names=remaining_dsets)
-        encoding = _get_netcdf_encoding(ds_remaining[["average_temporal_coherence"]], out_chunks)
-        ds_remaining[["average_temporal_coherence"]].to_netcdf(output_name, engine="h5netcdf", encoding=encoding, mode="a")
+        create_virtual_stack(
+            input_files=input_files, output=output_name, dataset_names=remaining_dsets
+        )
+        encoding = _get_netcdf_encoding(
+            ds_remaining[["average_temporal_coherence"]], out_chunks
+        )
+        ds_remaining[["average_temporal_coherence"]].to_netcdf(
+            output_name, engine="h5netcdf", encoding=encoding, mode="a"
+        )
     print(f"Wrote remaining at {time.time() - start_time:.1f}s")
 
     if reference_method == ReferenceMethod.HIGH_COHERENCE:
@@ -478,9 +506,12 @@ def reformat_stack_custom(
         transform = _get_transform(ds)
         crs = CRS.from_wkt(ds.spatial_ref.crs_wkt)
         ref_row, ref_col = _get_reference_row_col(
-            row=reference_row, col=reference_col,
-            lon=reference_lon, lat=reference_lat,
-            crs=crs, transform=transform,
+            row=reference_row,
+            col=reference_col,
+            lon=reference_lon,
+            lat=reference_lat,
+            crs=crs,
+            transform=transform,
         )
         good_pixel_mask = np.asarray(ds.water_mask) == 1
     elif reference_method in (ReferenceMethod.BORDER, ReferenceMethod.MEDIAN):
@@ -491,11 +522,14 @@ def reformat_stack_custom(
 
     correction_names = [str(c).split("/")[-1] for c in corrections]
     _write_rebased_stack(
-        ds, output_name, out_chunks=out_chunks,
+        ds,
+        output_name,
+        out_chunks=out_chunks,
         reference_datetimes=reference_datetimes,
         data_var=DisplacementDataset.DISPLACEMENT,
         reference_method=reference_method,
-        reference_row=ref_row, reference_col=ref_col,
+        reference_row=ref_row,
+        reference_col=ref_col,
         border_pixels=reference_border_pixels,
         good_pixel_mask=good_pixel_mask,
         out_format=out_format,
@@ -510,7 +544,9 @@ def reformat_stack_custom(
 
     if str(DisplacementDataset.SHORT_WAVELENGTH) in ds.data_vars:
         _write_rebased_stack(
-            ds, output_name, out_chunks=out_chunks,
+            ds,
+            output_name,
+            out_chunks=out_chunks,
             reference_datetimes=reference_datetimes,
             data_var=DisplacementDataset.SHORT_WAVELENGTH,
             out_format=out_format,
@@ -526,6 +562,7 @@ def reformat_stack_custom(
 
 
 # ── VELOCITY ──────────────────────────────────────────────────────────────────
+
 
 def add_velocity_to_zarr(zarr_path: str, weight_by_coherence: bool = True) -> None:
     """Estimate linear LOS velocity from displacement and append to zarr."""
@@ -550,13 +587,16 @@ def add_velocity_to_zarr(zarr_path: str, weight_by_coherence: bool = True) -> No
     print("Estimating velocity with dolphin...")
     vel = np.array(estimate_velocity(x_arr, disp, weight_stack))
 
-    ds_out = xr.Dataset({
-        "velocity": xr.DataArray(
-            vel.astype(np.float32), dims=("y", "x"),
-            coords={"y": ds.y, "x": ds.x},
-            attrs={"units": "m/yr", "long_name": "Linear LOS velocity"},
-        ),
-    })
+    ds_out = xr.Dataset(
+        {
+            "velocity": xr.DataArray(
+                vel.astype(np.float32),
+                dims=("y", "x"),
+                coords={"y": ds.y, "x": ds.x},
+                attrs={"units": "m/yr", "long_name": "Linear LOS velocity"},
+            ),
+        }
+    )
 
     encoding = {"velocity": {"compressors": [], "chunks": (256, 256)}}
     ds_out.to_zarr(zarr_path, mode="a", consolidated=False, encoding=encoding)
@@ -565,6 +605,7 @@ def add_velocity_to_zarr(zarr_path: str, weight_by_coherence: bool = True) -> No
 
 
 # ── RECHUNK ───────────────────────────────────────────────────────────────────
+
 
 def rechunk_zarr(zarr_path: str, out_path: str, chunks: dict = None) -> None:
     """Rechunk zarr store for efficient spatial access."""
@@ -589,7 +630,9 @@ def rechunk_zarr(zarr_path: str, out_path: str, chunks: dict = None) -> None:
 S1_WAVELENGTH_M = 0.05546576
 
 
-def _crop_tif(path: str | Path, xmin: float, ymin: float, xmax: float, ymax: float) -> np.ndarray:
+def _crop_tif(
+    path: str | Path, xmin: float, ymin: float, xmax: float, ymax: float
+) -> np.ndarray:
     """Read and crop a GeoTIFF to the given bounding box, returning a 2-D float32 array.
 
     nodata (0) is replaced with NaN.
@@ -623,19 +666,38 @@ def _to_db(amp: np.ndarray) -> np.ndarray:
     return np.where(amp > 0, 20.0 * np.log10(amp), np.nan).astype(np.float32)
 
 
-def _write_2d(zarr_path: str, name: str, data: np.ndarray, y, x, attrs: dict, chunks=(256, 256)):
-    da = xr.DataArray(data.astype(np.float32), dims=("y", "x"), coords={"y": y, "x": x}, attrs=attrs)
-    enc = {name: {"compressors": [], "chunks": chunks}}
-    da.to_dataset(name=name).to_zarr(zarr_path, mode="a", consolidated=False, encoding=enc)
-
-
-def _write_3d(zarr_path: str, name: str, data: np.ndarray, time_coords, y, x, attrs: dict, chunks=(4, 256, 256)):
+def _write_2d(
+    zarr_path: str, name: str, data: np.ndarray, y, x, attrs: dict, chunks=(256, 256)
+):
     da = xr.DataArray(
-        data.astype(np.float32), dims=("time", "y", "x"),
-        coords={"time": time_coords, "y": y, "x": x}, attrs=attrs,
+        data.astype(np.float32), dims=("y", "x"), coords={"y": y, "x": x}, attrs=attrs
     )
     enc = {name: {"compressors": [], "chunks": chunks}}
-    da.to_dataset(name=name).to_zarr(zarr_path, mode="a", consolidated=False, encoding=enc)
+    da.to_dataset(name=name).to_zarr(
+        zarr_path, mode="a", consolidated=False, encoding=enc
+    )
+
+
+def _write_3d(
+    zarr_path: str,
+    name: str,
+    data: np.ndarray,
+    time_coords,
+    y,
+    x,
+    attrs: dict,
+    chunks=(4, 256, 256),
+):
+    da = xr.DataArray(
+        data.astype(np.float32),
+        dims=("time", "y", "x"),
+        coords={"time": time_coords, "y": y, "x": x},
+        attrs=attrs,
+    )
+    enc = {name: {"compressors": [], "chunks": chunks}}
+    da.to_dataset(name=name).to_zarr(
+        zarr_path, mode="a", consolidated=False, encoding=enc
+    )
 
 
 def append_extra_layers(
@@ -683,53 +745,83 @@ def append_extra_layers(
     if not comp_slcs:
         print("  WARNING: no compressed SLC HDF5 found, skipping.")
     else:
+
         def _comp_dates(f: Path) -> tuple[str, str]:
             """Return (date_first, date_last) from compressed SLC filename."""
             m = re.search(r"compressed_\S+?_\d{8}_(\d{8})_(\d{8})\.h5", f.name)
             return (m.group(1), m.group(2)) if m else ("", "")
 
-        comp_info = [(d1, d2, f) for f in comp_slcs if "" not in (d := _comp_dates(f)) for d1, d2 in [d]]
+        comp_info = [
+            (d1, d2, f)
+            for f in comp_slcs
+            if "" not in (d := _comp_dates(f))
+            for d1, d2 in [d]
+        ]
         comp_info.sort(key=lambda t: t[0])
 
         # Crop indices (same for all files — shared grid)
         with h5py.File(comp_info[0][2]) as h:
-            xc = h["data/x_coordinates"][:]   # 5 m spacing
-            yc = h["data/y_coordinates"][:]   # 10 m spacing
+            xc = h["data/x_coordinates"][:]  # 5 m spacing
+            yc = h["data/y_coordinates"][:]  # 10 m spacing
         xi = np.where((xc >= xmin) & (xc <= xmax))[0]
         yi = np.where((yc >= ymin) & (yc <= ymax))[0]
         xi_s, xi_e = int(xi[0]), int(xi[-1]) + 1
         yi_s, yi_e = int(yi[0]), int(yi[-1]) + 1
-        xi_e -= (xi_e - xi_s) % 2   # ensure even length for ×2 multilook
+        xi_e -= (xi_e - xi_s) % 2  # ensure even length for ×2 multilook
 
         # Build full-time-axis arrays: each date gets the value of the ministack
         # that contains it; last ministack wins if ranges overlap.
-        mean_amp_3d  = np.full((len(sorted_dates), ny, nx), np.nan, dtype=np.float32)
-        adisp_3d     = np.full((len(sorted_dates), ny, nx), np.nan, dtype=np.float32)
+        mean_amp_3d = np.full((len(sorted_dates), ny, nx), np.nan, dtype=np.float32)
+        adisp_3d = np.full((len(sorted_dates), ny, nx), np.nan, dtype=np.float32)
 
         for date_first, date_last, f in comp_info:
             with h5py.File(f) as h:
-                vv    = h["data/VV"][yi_s:yi_e, xi_s:xi_e]
+                vv = h["data/VV"][yi_s:yi_e, xi_s:xi_e]
                 adisp = h["data/amplitude_dispersion"][yi_s:yi_e, xi_s:xi_e]
             amp = np.abs(vv).astype(np.float32)
-            amp_ml   = (amp[:,0::2]   + amp[:,1::2])   / 2
-            adisp_ml = (adisp[:,0::2] + adisp[:,1::2]) / 2
+            amp_ml = (amp[:, 0::2] + amp[:, 1::2]) / 2
+            adisp_ml = (adisp[:, 0::2] + adisp[:, 1::2]) / 2
             adisp_ml = adisp_ml.astype(np.float32)
             adisp_ml[adisp_ml <= 0] = np.nan
 
             for t_idx, d in enumerate(sorted_dates):
                 if date_first <= d <= date_last:
-                    mean_amp_3d[t_idx]  = _to_db(amp_ml)[:ny, :nx]
-                    adisp_3d[t_idx]     = adisp_ml[:ny, :nx]
+                    mean_amp_3d[t_idx] = _to_db(amp_ml)[:ny, :nx]
+                    adisp_3d[t_idx] = adisp_ml[:ny, :nx]
 
-        _write_3d(zarr_path, "mean_amplitude", mean_amp_3d, time_coords, y_coords, x_coords,
-                  {"long_name": "Compressed-SLC mean amplitude (|VV|, multilooked ×2 in x)",
-                   "units": "dB  (20*log10(linear amplitude))",
-                   "note": "constant within each ministack [date_first, date_last]"})
-        _write_3d(zarr_path, "amplitude_dispersion", adisp_3d, time_coords, y_coords, x_coords,
-                  {"long_name": "Amplitude dispersion (std/mean) from compressed SLC ministack",
-                   "note": "constant within each ministack [date_first, date_last]"})
-        print(f"  Written mean_amplitude, amplitude_dispersion  "
-              f"({len(comp_info)} ministacks → {len(sorted_dates)} time steps)")
+        _write_3d(
+            zarr_path,
+            "mean_amplitude",
+            mean_amp_3d,
+            time_coords,
+            y_coords,
+            x_coords,
+            {
+                "long_name": (
+                    "Compressed-SLC mean amplitude (|VV|, multilooked ×2 in x)"
+                ),
+                "units": "dB  (20*log10(linear amplitude))",
+                "note": "constant within each ministack [date_first, date_last]",
+            },
+        )
+        _write_3d(
+            zarr_path,
+            "amplitude_dispersion",
+            adisp_3d,
+            time_coords,
+            y_coords,
+            x_coords,
+            {
+                "long_name": (
+                    "Amplitude dispersion (std/mean) from compressed SLC ministack"
+                ),
+                "note": "constant within each ministack [date_first, date_last]",
+            },
+        )
+        print(
+            "  Written mean_amplitude, amplitude_dispersion  "
+            f"({len(comp_info)} ministacks → {len(sorted_dates)} time steps)"
+        )
 
     # ── 2. Stack quality summary metrics (2-D, from zarr variables) ───────────
     print("\n[2/6] Stack quality summary metrics (from zarr)...")
@@ -738,19 +830,42 @@ def append_extra_layers(
         return np.nanmedian(da.values.astype(np.float32), axis=0)
 
     med_tc = _nanmedian_2d(ds.temporal_coherence)
-    _write_2d(zarr_path, "median_temporal_coherence", med_tc, y_coords, x_coords,
-              {"long_name": "Median temporal coherence across stack", "units": "0-1"})
+    _write_2d(
+        zarr_path,
+        "median_temporal_coherence",
+        med_tc,
+        y_coords,
+        x_coords,
+        {"long_name": "Median temporal coherence across stack", "units": "0-1"},
+    )
 
     med_ps = _nanmedian_2d(ds.phase_similarity)
-    _write_2d(zarr_path, "median_phase_similarity", med_ps, y_coords, x_coords,
-              {"long_name": "Median phase similarity across stack", "units": "0-1"})
+    _write_2d(
+        zarr_path,
+        "median_phase_similarity",
+        med_ps,
+        y_coords,
+        x_coords,
+        {"long_name": "Median phase similarity across stack", "units": "0-1"},
+    )
 
-    sum_res = np.nansum(np.abs(ds.timeseries_inversion_residuals.values.astype(np.float32)), axis=0)
+    sum_res = np.nansum(
+        np.abs(ds.timeseries_inversion_residuals.values.astype(np.float32)), axis=0
+    )
     sum_res[sum_res == 0] = np.nan
-    _write_2d(zarr_path, "sum_inversion_residuals", sum_res, y_coords, x_coords,
-              {"long_name": "Sum of absolute timeseries inversion residuals", "units": "rad"})
+    _write_2d(
+        zarr_path,
+        "sum_inversion_residuals",
+        sum_res,
+        y_coords,
+        x_coords,
+        {"long_name": "Sum of absolute timeseries inversion residuals", "units": "rad"},
+    )
 
-    print("  Written median_temporal_coherence, median_phase_similarity, sum_inversion_residuals")
+    print(
+        "  Written median_temporal_coherence, median_phase_similarity,"
+        " sum_inversion_residuals"
+    )
 
     # ── 3. CRLB (time, y, x) ─────────────────────────────────────────────────
     print("\n[3/6] CRLB (phase std in rad + displacement uncertainty)...")
@@ -766,10 +881,10 @@ def append_extra_layers(
             for cf in sorted((ms_dir / "crlb").glob("crlb_*.tif")):
                 m = re.search(r"crlb_(\d{8})\.tif", cf.name)
                 if m:
-                    date_to_crlb[m.group(1)] = cf   # last batch wins
+                    date_to_crlb[m.group(1)] = cf  # last batch wins
 
     # Build time-ordered arrays aligned to zarr time axis
-    crlb_rad   = np.full((len(zarr_dates), ny, nx), np.nan, dtype=np.float32)
+    crlb_rad = np.full((len(zarr_dates), ny, nx), np.nan, dtype=np.float32)
     for t_idx, (date_str, _) in enumerate(sorted(zarr_dates.items())):
         cf = date_to_crlb.get(date_str)
         if cf is None:
@@ -778,16 +893,38 @@ def append_extra_layers(
         arr = _crop_tif(cf, xmin, ymin, xmax, ymax)
         crlb_rad[t_idx] = arr[:ny, :nx]
 
-    _write_3d(zarr_path, "crlb_rad", crlb_rad, time_coords, y_coords, x_coords,
-              {"long_name": "Cramér-Rao lower bound — phase std", "units": "rad"})
+    _write_3d(
+        zarr_path,
+        "crlb_rad",
+        crlb_rad,
+        time_coords,
+        y_coords,
+        x_coords,
+        {"long_name": "Cramér-Rao lower bound — phase std", "units": "rad"},
+    )
 
     # Convert to displacement uncertainty: sigma_d = (wavelength / 4π) * sigma_phi
     factor = wavelength / (4 * np.pi)
     crlb_disp = crlb_rad * factor
-    _write_3d(zarr_path, "crlb_displacement", crlb_disp, time_coords, y_coords, x_coords,
-              {"long_name": "Cramér-Rao lower bound — displacement uncertainty", "units": "m",
-               "wavelength_m": wavelength, "conversion": "wavelength / (4*pi) * crlb_rad"})
-    print(f"  Written crlb_rad, crlb_displacement ({sum(v is not None for v in [date_to_crlb.get(d) for d in zarr_dates])} dates matched)")
+    _write_3d(
+        zarr_path,
+        "crlb_displacement",
+        crlb_disp,
+        time_coords,
+        y_coords,
+        x_coords,
+        {
+            "long_name": "Cramér-Rao lower bound — displacement uncertainty",
+            "units": "m",
+            "wavelength_m": wavelength,
+            "conversion": "wavelength / (4*pi) * crlb_rad",
+        },
+    )
+    print(
+        "  Written crlb_rad, crlb_displacement"
+        f" ({sum(v is not None for v in [date_to_crlb.get(d) for d in zarr_dates])}"
+        " dates matched)"
+    )
 
     # ── 4. Per-date amplitude (dB) + stack amplitude dispersion from GSLC ──────
     print("\n[4/6] Per-date amplitude (dB) from GSLC HDF5...")
@@ -822,9 +959,18 @@ def append_extra_layers(
         amplitude[t_idx] = _to_db(amp_ml)[:ny, :nx]
         matched += 1
 
-    _write_3d(zarr_path, "amplitude", amplitude, time_coords, y_coords, x_coords,
-              {"long_name": "Per-date amplitude from GSLC (multilook ×2 in x)",
-               "units": "dB  (20*log10(linear amplitude))"})
+    _write_3d(
+        zarr_path,
+        "amplitude",
+        amplitude,
+        time_coords,
+        y_coords,
+        x_coords,
+        {
+            "long_name": "Per-date amplitude from GSLC (multilook ×2 in x)",
+            "units": "dB  (20*log10(linear amplitude))",
+        },
+    )
     print(f"  Written amplitude (dB) ({matched}/{len(sorted_dates)} dates matched)")
 
     # ── 5. Stack amplitude dispersion + mean amplitude dB from zarr (2-D) ──────
@@ -832,26 +978,44 @@ def append_extra_layers(
     # All stats computed in linear space; mean amplitude also stored in dB.
     print("\n[5/6] Stack amplitude dispersion + mean amplitude dB from zarr...")
     ds2 = xr.open_zarr(zarr_path)
-    amp_db = ds2["amplitude"].values.astype(np.float32)        # (time, y, x)
+    amp_db = ds2["amplitude"].values.astype(np.float32)  # (time, y, x)
     amp_lin = np.where(np.isfinite(amp_db), 10.0 ** (amp_db / 20.0), np.nan)
     with np.errstate(invalid="ignore", divide="ignore"):
         amp_mean_lin = np.nanmean(amp_lin, axis=0)
-        amp_std      = np.nanstd(amp_lin, axis=0, ddof=1)
+        amp_std = np.nanstd(amp_lin, axis=0, ddof=1)
         stack_amp_disp = np.where(amp_mean_lin > 0, amp_std / amp_mean_lin, np.nan)
-        amp_mean_db    = np.where(amp_mean_lin > 0, 20.0 * np.log10(amp_mean_lin), np.nan)
+        amp_mean_db = np.where(amp_mean_lin > 0, 20.0 * np.log10(amp_mean_lin), np.nan)
 
-    _write_2d(zarr_path, "mean_amplitude_db", amp_mean_db.astype(np.float32),
-              y_coords, x_coords,
-              {"long_name": "Time-mean amplitude from full GSLC stack",
-               "units": "dB  (20*log10(mean linear amplitude))",
-               "note": f"mean computed in linear space, then converted to dB ({matched} dates)"})
-    _write_2d(zarr_path, "stack_amplitude_dispersion", stack_amp_disp.astype(np.float32),
-              y_coords, x_coords,
-              {"long_name": "Amplitude dispersion from full GSLC stack (std/mean, linear)",
-               "units": "dimensionless",
-               "note": f"computed from zarr amplitude variable ({matched} dates)"})
+    _write_2d(
+        zarr_path,
+        "mean_amplitude_db",
+        amp_mean_db.astype(np.float32),
+        y_coords,
+        x_coords,
+        {
+            "long_name": "Time-mean amplitude from full GSLC stack",
+            "units": "dB  (20*log10(mean linear amplitude))",
+            "note": (
+                f"mean computed in linear space, then converted to dB ({matched} dates)"
+            ),
+        },
+    )
+    _write_2d(
+        zarr_path,
+        "stack_amplitude_dispersion",
+        stack_amp_disp.astype(np.float32),
+        y_coords,
+        x_coords,
+        {
+            "long_name": "Amplitude dispersion from full GSLC stack (std/mean, linear)",
+            "units": "dimensionless",
+            "note": f"computed from zarr amplitude variable ({matched} dates)",
+        },
+    )
     print(f"  Written mean_amplitude_db (mean={np.nanmean(amp_mean_db):.1f} dB)")
-    print(f"  Written stack_amplitude_dispersion (mean={np.nanmean(stack_amp_disp):.3f})")
+    print(
+        f"  Written stack_amplitude_dispersion (mean={np.nanmean(stack_amp_disp):.3f})"
+    )
 
     # ── 6. Consolidate ────────────────────────────────────────────────────────
     print("\n[6/6] Consolidating zarr metadata...")
@@ -897,9 +1061,9 @@ def run_processing(
     # Number of acquisition dates common to all bursts (indices align across bursts).
     n_dates = min(len(v) for v in reals_by_burst.values())
 
-    n_hist = n_dates // ms_size          # full historical ministacks
-    hist_count = n_hist * ms_size        # real dates consumed by historical
-    n_forward = n_dates - hist_count     # leftover dates → one forward run each
+    n_hist = n_dates // ms_size  # full historical ministacks
+    hist_count = n_hist * ms_size  # real dates consumed by historical
+    n_forward = n_dates - hist_count  # leftover dates → one forward run each
     print(
         f"{n_bursts} burst(s), {n_dates} date(s): {n_hist} historical ministack(s) "
         f"of {ms_size} + {n_forward} forward product(s), {len(files)} total CSLCs"
@@ -984,8 +1148,9 @@ def run_processing(
             f"[historical {ms_i + 1}/{n_hist}] date idx {s}-{e - 1}  "
             f"reals={len(batch_cslcs)}  ccslc_in={len(comp_slc_files)}"
         )
-        _run_batch(batch_cslcs, comp_slc_files, work_dir, output_dir,
-                   ProcessingMode.HISTORICAL)
+        _run_batch(
+            batch_cslcs, comp_slc_files, work_dir, output_dir, ProcessingMode.HISTORICAL
+        )
         _harvest_compressed(output_dir, work_dir)
 
         new_amp_disp = sorted(work_dir.rglob("*_amp_dispersion.tif"))
@@ -994,7 +1159,10 @@ def run_processing(
             amp_disp_files = new_amp_disp
         if new_amp_mean:
             amp_mean_files = new_amp_mean
-        print(f"  → compressed store: {len(_pick_comp(max_comp))} (latest {max_comp}/burst)")
+        print(
+            f"  → compressed store: {len(_pick_comp(max_comp))} (latest"
+            f" {max_comp}/burst)"
+        )
         run_idx += 1
 
     # ── Forward products (one run per leftover date) ──────────────────────────
@@ -1002,7 +1170,7 @@ def run_processing(
     # run_no_corrections keeps only the newest date's product, so one product/run.
     for k, n in enumerate(range(hist_count, n_dates)):
         s = max(0, n - (forward_window - 1))
-        batch_cslcs = [f for b in burst_ids for f in reals_by_burst[b][s:n + 1]]
+        batch_cslcs = [f for b in burst_ids for f in reals_by_burst[b][s : n + 1]]
         comp_fwd = _pick_comp(1)  # exactly 1 ccslc per burst
         if not comp_fwd:
             raise SystemExit("No compressed SLC available for forward mode.")
@@ -1015,8 +1183,7 @@ def run_processing(
             f"window reals idx {s}-{n} ({len(batch_cslcs)} files)  "
             f"ccslc={len(comp_fwd)}"
         )
-        _run_batch(batch_cslcs, comp_fwd, work_dir, output_dir,
-                   ProcessingMode.FORWARD)
+        _run_batch(batch_cslcs, comp_fwd, work_dir, output_dir, ProcessingMode.FORWARD)
         run_idx += 1
 
 
@@ -1047,43 +1214,65 @@ def build_parser() -> argparse.ArgumentParser:
     )
     # ── Optional processing knobs ──
     p.add_argument(
-        "-ms", "--ministack-size", type=int, default=DEFAULT_MS_SIZE,
+        "-ms",
+        "--ministack-size",
+        type=int,
+        default=DEFAULT_MS_SIZE,
         help="Number of acquisitions per ministack.",
     )
     p.add_argument(
-        "--num-compressed", type=int, default=DEFAULT_MAX_COMP,
+        "--num-compressed",
+        type=int,
+        default=DEFAULT_MAX_COMP,
         help="Compressed SLCs carried forward per burst (historical).",
     )
     p.add_argument(
-        "--forward-window", type=int, default=DEFAULT_FORWARD_WINDOW,
-        help="Real SLCs per forward run (window ending at the product date, e.g. "
-             "5 → n-4,n-3,n-2,n-1,n). Each forward run also uses 1 compressed SLC.",
+        "--forward-window",
+        type=int,
+        default=DEFAULT_FORWARD_WINDOW,
+        help=(
+            "Real SLCs per forward run (window ending at the product date, e.g. "
+            "5 → n-4,n-3,n-2,n-1,n). Each forward run also uses 1 compressed SLC."
+        ),
     )
     p.add_argument(
-        "--buffer", type=float, default=DEFAULT_BUFFER,
+        "--buffer",
+        type=float,
+        default=DEFAULT_BUFFER,
         help="Padding (metres) added around the extent bbox.",
     )
     p.add_argument("--gpu", action="store_true", help="Enable GPU (JAX) processing.")
     p.add_argument(
-        "--gslc-glob", default=DEFAULT_GSLC_GLOB,
+        "--gslc-glob",
+        default=DEFAULT_GSLC_GLOB,
         help="Glob for (G)SLC HDF5 files under --cslc-dir (any burst id by default).",
     )
     p.add_argument(
-        "--zarr-out", type=Path, default=None,
+        "--zarr-out",
+        type=Path,
+        default=None,
         help="Output zarr path (default: <work-dir>/disp.zarr).",
     )
     p.add_argument(
-        "--reference-coherence-threshold", type=float, default=0.7,
+        "--reference-coherence-threshold",
+        type=float,
+        default=0.7,
         help="Coherence threshold for HIGH_COHERENCE reference selection.",
     )
     p.add_argument(
-        "--weight-by-coherence", action="store_true",
+        "--weight-by-coherence",
+        action="store_true",
         help="Weight the velocity fit by average temporal coherence.",
     )
     p.add_argument(
-        "--stages", nargs="+", choices=STAGES, default=list(STAGES),
-        help="Which pipeline stages to run (default: all). Later stages reuse "
-             "existing outputs, so you can re-run e.g. only 'velocity extra'.",
+        "--stages",
+        nargs="+",
+        choices=STAGES,
+        default=list(STAGES),
+        help=(
+            "Which pipeline stages to run (default: all). Later stages reuse "
+            "existing outputs, so you can re-run e.g. only 'velocity extra'."
+        ),
     )
     return p
 
@@ -1127,14 +1316,16 @@ def main(argv: list[str] | None = None) -> None:
             apply_ionospheric_corrections=False,
             quality_datasets=None,
             quality_thresholds=None,
-            reference_method=ReferenceMethod.HIGH_COHERENCE,
+            reference_method=None,  # -> HIGH_COHERENCE (resolved inside)
             reference_coherence_threshold=args.reference_coherence_threshold,
             out_chunks=(4, 256, 256),
         )
 
     if "velocity" in args.stages:
         print("\nEstimating velocity...")
-        add_velocity_to_zarr(str(zarr_out), weight_by_coherence=args.weight_by_coherence)
+        add_velocity_to_zarr(
+            str(zarr_out), weight_by_coherence=args.weight_by_coherence
+        )
 
     if "extra" in args.stages:
         print("\nAppending extra layers...")

--- a/scripts/disp_s1_process.py
+++ b/scripts/disp_s1_process.py
@@ -1,0 +1,1152 @@
+"""
+Standalone DISP-S1 processing pipeline (Sentinel-1), driven from the CLI.
+
+Given a directory of CSLC/GSLC bursts, this runs the full local pipeline for an
+arbitrary site/track/frame:
+
+  1. Group CSLCs by burst, create ministacks, run dolphin/disp_s1 per batch,
+     carrying compressed SLCs forward between ministacks.
+  2. Reformat per-ministack .nc outputs into a single rebased zarr stack.
+  3. Estimate linear LOS velocity and append to zarr.
+  4. Append extra layers (amplitude, CRLB, stack quality metrics).
+
+All site-specific values (input dir, work dir, frame id, spatial extent,
+ministack size, ...) are command-line arguments; nothing is hardcoded to a
+particular acquisition. Run ``python disp_s1_process.py --help`` for options.
+
+Example
+-------
+    python disp_s1_process.py \\
+        --cslc-dir /path/to/gslcs/t161_343970_iw2 \\
+        --work-dir /path/to/results \\
+        --frame-id 42997 \\
+        --extent "4.3561,51.0951 : 4.373,51.1031" \\
+        --ministack-size 15 --buffer 500
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import logging
+import os
+import re
+import shutil
+import sys
+import time
+import warnings
+from collections.abc import Sequence
+from dataclasses import asdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import h5py
+import numpy as np
+import pandas as pd
+import rasterio
+import rioxarray  # noqa: F401
+import xarray as xr
+import zarr
+from pyproj import CRS, Transformer
+from rasterio.windows import from_bounds
+
+from dolphin._log import setup_logging
+from dolphin.stack import CompressedSlcPlan
+from dolphin.timeseries import estimate_velocity, datetime_to_float
+from dolphin.utils import get_max_memory_usage
+from dolphin.workflows import PreprocessOptions, SnaphuOptions
+from dolphin.workflows.config import (
+    DisplacementWorkflow,
+    HalfWindow,
+    InputOptions,
+    InterferogramNetwork,
+    OutputOptions,
+    PhaseLinkingOptions,
+    PsOptions,
+    Strides,
+    UnwrapOptions,
+)
+from dolphin.workflows.corrections import CorrectionOptions
+from dolphin.workflows.displacement import run as run_displacement
+
+from disp_s1 import __version__
+from disp_s1 import main as disp_s1_main
+from disp_s1._masking import create_mask_from_distance
+from disp_s1._ps import precompute_ps
+from disp_s1.main import (
+    OutputPathsWithCorrections,
+    _assert_no_duplicate_dates,
+    _filter_before_last_processed,
+    create_products,
+)
+from disp_s1.pge_runconfig import (
+    AlgorithmParameters,
+    DynamicAncillaryFileGroup,
+    InputFileGroup,
+    PrimaryExecutable,
+    ProcessingMode,
+    ProductPathGroup,
+    RunConfig,
+    StaticAncillaryFileGroup,
+)
+
+from opera_utils import OPERA_DATASET_NAME, group_by_burst
+from opera_utils.disp._enums import (
+    CorrectionDataset,
+    DisplacementDataset,
+    QualityDataset,
+    ReferenceMethod,
+)
+from opera_utils.disp._netcdf import create_virtual_stack
+from opera_utils.disp._rebase import NaNPolicy, create_rebased_displacement
+from opera_utils.disp._reference import _get_reference_row_col, get_reference_values
+from opera_utils.disp._reformat import (
+    _get_zarr_encoding,
+    _get_transform,
+    _to_shard_dict,
+    _write_rebased_stack,
+    combine_quality_masks,
+)
+from opera_utils.disp._utils import _clamp_chunk_dict, _get_netcdf_encoding, round_mantissa
+from opera_utils import group_by_date
+
+# ── DEFAULTS ──────────────────────────────────────────────────────────────────
+# Site-specific values now come from the CLI (see build_parser / main).
+DEFAULT_MS_SIZE = 15        # acquisitions per ministack
+DEFAULT_BUFFER = 500.0      # metres of padding around the requested extent
+DEFAULT_MAX_COMP = 5        # compressed SLCs carried forward per burst (historical)
+DEFAULT_FORWARD_WINDOW = 5  # real SLCs per forward run: n-4, n-3, n-2, n-1, n
+DEFAULT_GSLC_GLOB = "t*.h5"  # pattern matching (G)SLC HDF5 files, any burst id
+
+# Keep JAX/XLA memory modest so it plays nice on shared GPUs.
+os.environ.setdefault("XLA_PYTHON_CLIENT_MEM_FRACTION", "0.1")
+
+# ── HELPERS ───────────────────────────────────────────────────────────────────
+
+def make_cfg(
+    cslc_files: list[Path],
+    work_dir: Path,
+    comp_slc_files: list[Path],
+    amp_disp_files: list[Path],
+    amp_mean_files: list[Path],
+    epsg=None,
+    bounds: list = None,
+    gpu: bool = False,
+    compressed_slc_plan: CompressedSlcPlan = CompressedSlcPlan.LAST_PER_MINISTACK,
+    output_reference_idx: int = None,
+    ministack_size: int = DEFAULT_MS_SIZE,
+) -> DisplacementWorkflow:
+    return DisplacementWorkflow(
+        cslc_file_list=comp_slc_files + cslc_files,
+        input_options=InputOptions(subdataset=OPERA_DATASET_NAME),
+        work_directory=work_dir,
+        amplitude_dispersion_files=amp_disp_files,
+        amplitude_mean_files=amp_mean_files,
+        phase_linking=PhaseLinkingOptions(
+            ministack_size=ministack_size,
+            max_num_compressed=5,
+            output_reference_idx=output_reference_idx,
+            half_window=HalfWindow(y=3, x=7),
+            use_evd=False,
+            beta=0.0,
+            zero_correlation_threshold=0.0,
+            shp_method='glrt',
+            shp_alpha=0.001,
+            mask_input_ps=False,
+            baseline_lag=None,
+            compressed_slc_plan=compressed_slc_plan,
+        ),
+        interferogram_network=InterferogramNetwork(max_bandwidth=3),
+        output_options=OutputOptions(
+            strides=Strides(x=2, y=1),
+            bounds=bounds,
+            bounds_epsg=epsg,
+        ),
+        ps_options=PsOptions(amp_dispersion_threshold=0.25),
+        unwrap_options=UnwrapOptions(
+            run_unwrap=True,
+            run_interpolation=True,
+            preprocess_options=PreprocessOptions(
+                alpha=0.5,
+                max_radius=150,
+                interpolation_cor_threshold=0.001,
+                interpolation_similarity_threshold=0.4,
+            ),
+            snaphu_options=SnaphuOptions(
+                ntiles=(1, 1),
+                tile_overlap=(0, 0),
+                n_parallel_tiles=1,
+                single_tile_reoptimize=False,
+            ),
+        ),
+        worker_settings={"gpu_enabled": gpu, "threads_per_worker": 8, "n_parallel_bursts": 1},
+    )
+
+
+def make_pge_runconfig(
+    cfg: DisplacementWorkflow,
+    frame_id: int,
+    mode: ProcessingMode,
+    work_dir: Path,
+    output_dir: Path,
+    save_compressed_slc: bool = True,
+) -> RunConfig:
+    alg_params_file = work_dir / "algorithm_parameters.yaml"
+    algo_keys = set(AlgorithmParameters.model_fields.keys())
+    alg_params = AlgorithmParameters(
+        **cfg.model_dump(include=algo_keys),
+        spatial_wavelength_cutoff=50.0,
+    )
+    alg_params.to_yaml(alg_params_file)
+
+    return RunConfig(
+        input_file_group=InputFileGroup(
+            cslc_file_list=cfg.cslc_file_list,
+            frame_id=frame_id,
+        ),
+        dynamic_ancillary_file_group=DynamicAncillaryFileGroup(
+            algorithm_parameters_file=alg_params_file,
+            mask_file=cfg.mask_file,
+        ),
+        static_ancillary_file_group=StaticAncillaryFileGroup(),
+        primary_executable=PrimaryExecutable(
+            product_type=f"DISP_S1_{mode.value.upper()}",
+        ),
+        product_path_group=ProductPathGroup(
+            product_path=output_dir,
+            scratch_path=work_dir,
+            sas_output_path=output_dir,
+            save_compressed_slc=save_compressed_slc,
+        ),
+        worker_settings=cfg.worker_settings,
+    )
+
+
+def extent_to_projected_bbox(extent_str: str, gslc_file: Path):
+    """Convert 'minlon,minlat : maxlon,maxlat' extent to projected bbox from GSLC CRS."""
+    left, right = extent_str.split(" : ")
+    minlon, minlat = map(float, left.split(","))
+    maxlon, maxlat = map(float, right.split(","))
+
+    ds = xr.open_dataset(gslc_file, group="/data")
+    crs_wkt = ds["projection"].attrs["spatial_ref"]
+    crs = CRS.from_wkt(crs_wkt)
+    epsg = crs.to_epsg()
+    ds.close()
+
+    transformer = Transformer.from_crs("EPSG:4326", crs_wkt, always_xy=True)
+    minx, miny = transformer.transform(minlon, minlat)
+    maxx, maxy = transformer.transform(maxlon, maxlat)
+
+    return minx, miny, maxx, maxy, epsg
+
+
+@contextlib.contextmanager
+def _quiet_logging(log_file):
+    """Redirect all dolphin/disp_s1 logging to file; suppress stderr."""
+    target_loggers = [
+        logging.getLogger(name)
+        for name in ("dolphin", "disp_s1", "opera_utils", "root", "")
+    ] + [logging.root]
+
+    removed = []
+    for lgr in target_loggers:
+        for hdlr in list(lgr.handlers):
+            if isinstance(hdlr, logging.StreamHandler) and not isinstance(
+                hdlr, logging.FileHandler
+            ):
+                lgr.removeHandler(hdlr)
+                removed.append((lgr, hdlr))
+
+    old_stderr = sys.stderr
+    sys.stderr = open(log_file, "a")
+    try:
+        yield
+    finally:
+        sys.stderr.close()
+        sys.stderr = old_stderr
+        for lgr, hdlr in removed:
+            lgr.addHandler(hdlr)
+
+
+def _ensure_correction_options(cfg):
+    if not hasattr(cfg, "correction_options"):
+        cfg.correction_options = CorrectionOptions()
+
+
+def run_no_corrections(cfg: DisplacementWorkflow, pge_runconfig: RunConfig, debug: bool = False):
+    """Run disp_s1 without the corrections workflow (no geometry files available)."""
+    cfg.work_directory.mkdir(exist_ok=True, parents=True)
+    if cfg.log_file is None:
+        cfg.log_file = cfg.work_directory / "dolphin.log"
+    setup_logging(logger_name="disp_s1", debug=debug, filename=cfg.log_file)
+    with _quiet_logging(cfg.log_file):
+        processing_start_datetime = datetime.now(timezone.utc)
+
+        _assert_no_duplicate_dates(cfg.cslc_file_list)
+
+        is_forward = pge_runconfig.primary_executable.product_type == "DISP_S1_FORWARD"
+        if is_forward:
+            date_to_files = group_by_date(cfg.cslc_file_list, date_idx=0)
+            datetimes_present = list(date_to_files.keys())
+            *_, (second_to_last_date,), (_last_date,) = datetimes_present
+            second_to_last_date = second_to_last_date.replace(tzinfo=None)
+            if pge_runconfig.input_file_group.last_processed is None:
+                pge_runconfig.input_file_group.last_processed = (
+                    second_to_last_date + timedelta(days=1)
+                )
+
+        if pge_runconfig.dynamic_ancillary_file_group.mask_file:
+            water_binary_mask = cfg.work_directory / "water_binary_mask.tif"
+            create_mask_from_distance(
+                water_distance_file=pge_runconfig.dynamic_ancillary_file_group.mask_file,
+                output_file=water_binary_mask,
+                land_buffer=1,
+                ocean_buffer=1,
+            )
+            cfg.mask_file = water_binary_mask
+
+        if any("compressed" in f.name.lower() for f in cfg.cslc_file_list):
+            combined_dispersion_files, combined_mean_files = precompute_ps(cfg=cfg)
+            cfg.amplitude_dispersion_files = combined_dispersion_files
+            cfg.amplitude_mean_files = combined_mean_files
+        else:
+            cfg.ps_options.amp_dispersion_threshold = 0.15
+
+        out_paths = run_displacement(cfg=cfg, debug=debug)
+
+        assert out_paths.timeseries_paths is not None
+        assert out_paths.timeseries_residual_paths is not None
+
+        if is_forward:
+            from dolphin.timeseries import _redo_reference
+            final_ts_paths, final_residual_paths = _redo_reference(
+                out_paths.timeseries_paths,
+                out_paths.timeseries_residual_paths,
+                second_to_last_date,
+                bad_pixel_mask=np.ma.nomask,
+            )
+            out_paths.timeseries_paths = final_ts_paths
+            out_paths.timeseries_residual_paths = final_residual_paths
+
+        if last_processed := pge_runconfig.input_file_group.last_processed:
+            out_paths = _filter_before_last_processed(out_paths, last_processed)
+
+        _ensure_correction_options(cfg)
+
+        out_paths_with_corr = OutputPathsWithCorrections(
+            **asdict(out_paths),
+            ionospheric_corrections=None,
+        )
+
+        create_products(
+            out_paths=out_paths_with_corr,
+            cfg=cfg,
+            pge_runconfig=pge_runconfig,
+            processing_start_datetime=processing_start_datetime,
+        )
+
+        max_mem = get_max_memory_usage(units="GB")
+        print(f"Max memory usage: {max_mem:.2f} GB")
+        print(f"disp_s1 version: {__version__}")
+
+
+# ── REFORMAT ──────────────────────────────────────────────────────────────────
+
+_FNAME_RE = re.compile(r"(\d{8})_(\d{8})\.nc$")
+
+
+def _parse_dates_from_filename(path: Path) -> tuple[datetime, datetime]:
+    m = _FNAME_RE.search(path.name)
+    if not m:
+        raise ValueError(f"Cannot parse dates from filename: {path.name}")
+    ref = datetime.strptime(m.group(1), "%Y%m%d").replace(tzinfo=timezone.utc)
+    sec = datetime.strptime(m.group(2), "%Y%m%d").replace(tzinfo=timezone.utc)
+    return ref, sec
+
+
+def reformat_stack_custom(
+    input_files: list[Path],
+    output_name: str,
+    out_chunks: tuple[int, int, int] = (4, 256, 256),
+    shard_factors: tuple[int, int, int] = (1, 4, 4),
+    drop_vars: Sequence[str] | None = None,
+    apply_solid_earth_corrections: bool = True,
+    apply_ionospheric_corrections: bool = False,
+    quality_datasets: Sequence[str] | None = ["recommended_mask"],
+    quality_thresholds: Sequence[float] | None = [0.5],
+    reference_method: ReferenceMethod = ReferenceMethod.HIGH_COHERENCE,
+    reference_row: int | None = None,
+    reference_col: int | None = None,
+    reference_lon: float | None = None,
+    reference_lat: float | None = None,
+    reference_border_pixels: int = 3,
+    reference_coherence_threshold: float = 0.7,
+    process_chunk_size: tuple[int, int] = (2048, 2048),
+    do_round: bool = True,
+) -> None:
+    """Reformat per-ministack .nc outputs into a unified zarr/netcdf stack."""
+    start_time = time.time()
+
+    if Path(output_name).suffix == ".nc":
+        out_format = "h5netcdf"
+    elif Path(output_name).suffix == ".zarr":
+        out_format = "zarr"
+    else:
+        raise ValueError("Only .nc and .zarr output formats are supported")
+
+    if drop_vars is None:
+        drop_vars = []
+
+    corrections: list[CorrectionDataset] = []
+    if apply_solid_earth_corrections:
+        corrections.append(CorrectionDataset.SOLID_EARTH_TIDE)
+    if apply_ionospheric_corrections:
+        corrections.append(CorrectionDataset.IONOSPHERIC_DELAY)
+
+    out_chunk_dict = dict(zip(["time", "y", "x"], out_chunks))
+    out_shard_dict = _to_shard_dict(out_chunks, shard_factors)
+
+    input_files = sorted(input_files, key=lambda p: _parse_dates_from_filename(p))
+
+    reference_datetimes = pd.DatetimeIndex(
+        [_parse_dates_from_filename(p)[0].replace(tzinfo=None) for p in input_files]
+    )
+
+    process_chunk_dict = {"time": 1, "y": process_chunk_size[0], "x": process_chunk_size[1]}
+
+    ds = xr.open_mfdataset(input_files, engine="h5netcdf", chunks=process_chunk_dict)
+    ds_corrections = xr.open_mfdataset(
+        input_files, engine="h5netcdf", group="corrections", chunks=process_chunk_dict
+    )
+    ds_bperp = ds_corrections["perpendicular_baseline"].isel(
+        y=ds_corrections.y.shape[0] // 2, x=ds_corrections.x.shape[0] // 2
+    )
+
+    ds = ds.drop_vars(drop_vars, errors="ignore")
+
+    all_vars = list(ds.data_vars)
+    minimal_vars = ["spatial_ref", "reference_time", "water_mask"]
+    ds_minimal = ds.drop_vars([v for v in all_vars if v not in minimal_vars])
+    ds_minimal["water_mask"] = ds_minimal["water_mask"].isel(time=0)
+    ds_minimal["perpendicular_baseline"] = ds_bperp
+
+    if out_format == "zarr":
+        encoding = _get_zarr_encoding(ds_minimal, out_chunks, add_coords=True)
+        ds_minimal.chunk(out_shard_dict).to_zarr(output_name, encoding=encoding, mode="w", consolidated=False)
+    else:
+        encoding = _get_netcdf_encoding(ds_minimal, out_chunks)
+        ds_minimal.to_netcdf(output_name, engine="h5netcdf", encoding=encoding, mode="w")
+    print(f"Wrote minimal dataset in {time.time() - start_time:.1f}s")
+
+    QUALITY_DATASETS = list(QualityDataset)
+    remaining_dsets = [
+        str(d) for d in QUALITY_DATASETS
+        if d != "water_mask" and str(d) not in drop_vars
+    ]
+    ds_remaining = ds[remaining_dsets].chunk({
+        "time": out_shard_dict["time"],
+        "y": process_chunk_dict["y"],
+        "x": process_chunk_dict["x"],
+    })
+    da_temp_coh = ds.temporal_coherence[::15]
+    avg_coherence = da_temp_coh.shape[0] / (1.0 / da_temp_coh).sum(dim="time", skipna=False, min_count=1)
+    ds_remaining["average_temporal_coherence"] = xr.DataArray(
+        avg_coherence, dims=("y", "x"), coords={"y": ds.y, "x": ds.x}
+    )
+    for var in ds_remaining.data_vars:
+        d = ds_remaining[var]
+        if do_round and np.issubdtype(d.dtype, np.floating):
+            d.data = round_mantissa(d.data, keep_bits=7)
+
+    print(f"Writing remaining variables: {list(ds_remaining.data_vars)}")
+    if out_format == "zarr":
+        encoding = _get_zarr_encoding(ds_remaining, out_chunks)
+        ds_remaining.to_zarr(output_name, encoding=encoding, mode="a", consolidated=False)
+    else:
+        create_virtual_stack(input_files=input_files, output=output_name, dataset_names=remaining_dsets)
+        encoding = _get_netcdf_encoding(ds_remaining[["average_temporal_coherence"]], out_chunks)
+        ds_remaining[["average_temporal_coherence"]].to_netcdf(output_name, engine="h5netcdf", encoding=encoding, mode="a")
+    print(f"Wrote remaining at {time.time() - start_time:.1f}s")
+
+    if reference_method == ReferenceMethod.HIGH_COHERENCE:
+        good_pixel_mask = avg_coherence > reference_coherence_threshold
+        ref_row = ref_col = None
+    elif reference_method == ReferenceMethod.POINT:
+        transform = _get_transform(ds)
+        crs = CRS.from_wkt(ds.spatial_ref.crs_wkt)
+        ref_row, ref_col = _get_reference_row_col(
+            row=reference_row, col=reference_col,
+            lon=reference_lon, lat=reference_lat,
+            crs=crs, transform=transform,
+        )
+        good_pixel_mask = np.asarray(ds.water_mask) == 1
+    elif reference_method in (ReferenceMethod.BORDER, ReferenceMethod.MEDIAN):
+        good_pixel_mask = np.asarray(ds.water_mask) == 1
+        ref_row = ref_col = None
+    else:
+        raise ValueError(f"Unknown ReferenceMethod {reference_method}")
+
+    correction_names = [str(c).split("/")[-1] for c in corrections]
+    _write_rebased_stack(
+        ds, output_name, out_chunks=out_chunks,
+        reference_datetimes=reference_datetimes,
+        data_var=DisplacementDataset.DISPLACEMENT,
+        reference_method=reference_method,
+        reference_row=ref_row, reference_col=ref_col,
+        border_pixels=reference_border_pixels,
+        good_pixel_mask=good_pixel_mask,
+        out_format=out_format,
+        ds_corrections=ds_corrections[correction_names] if corrections else None,
+        quality_datasets=quality_datasets,
+        quality_thresholds=quality_thresholds,
+        process_chunk_size=process_chunk_size,
+        shard_factors=shard_factors,
+        do_round=do_round,
+    )
+    print(f"Wrote displacement at {time.time() - start_time:.1f}s")
+
+    if str(DisplacementDataset.SHORT_WAVELENGTH) in ds.data_vars:
+        _write_rebased_stack(
+            ds, output_name, out_chunks=out_chunks,
+            reference_datetimes=reference_datetimes,
+            data_var=DisplacementDataset.SHORT_WAVELENGTH,
+            out_format=out_format,
+            process_chunk_size=process_chunk_size,
+            shard_factors=shard_factors,
+            do_round=do_round,
+        )
+        print(f"Wrote short_wavelength_displacement at {time.time() - start_time:.1f}s")
+
+    if out_format == "zarr":
+        zarr.consolidate_metadata(output_name)
+        print(f"Consolidated zarr metadata at {time.time() - start_time:.1f}s")
+
+
+# ── VELOCITY ──────────────────────────────────────────────────────────────────
+
+def add_velocity_to_zarr(zarr_path: str, weight_by_coherence: bool = True) -> None:
+    """Estimate linear LOS velocity from displacement and append to zarr."""
+    ds = xr.open_zarr(zarr_path)
+    da = ds["displacement"]
+
+    dates = da.time.values.astype("datetime64[s]").tolist()
+    x_arr = datetime_to_float(dates)
+
+    print("Loading displacement...")
+    disp = np.array(da.values, dtype=np.float32)
+
+    if weight_by_coherence and "average_temporal_coherence" in ds:
+        coh = np.array(ds["average_temporal_coherence"].values, dtype=np.float32)
+        weight_stack = np.broadcast_to(coh[np.newaxis], disp.shape).copy()
+        weight_stack[~np.isfinite(disp)] = 0.0
+    else:
+        weight_stack = None
+
+    disp = np.where(np.isfinite(disp), disp, 0.0)
+
+    print("Estimating velocity with dolphin...")
+    vel = np.array(estimate_velocity(x_arr, disp, weight_stack))
+
+    ds_out = xr.Dataset({
+        "velocity": xr.DataArray(
+            vel.astype(np.float32), dims=("y", "x"),
+            coords={"y": ds.y, "x": ds.x},
+            attrs={"units": "m/yr", "long_name": "Linear LOS velocity"},
+        ),
+    })
+
+    encoding = {"velocity": {"compressors": [], "chunks": (256, 256)}}
+    ds_out.to_zarr(zarr_path, mode="a", consolidated=False, encoding=encoding)
+    zarr.consolidate_metadata(zarr_path)
+    print("Done — velocity written to zarr.")
+
+
+# ── RECHUNK ───────────────────────────────────────────────────────────────────
+
+def rechunk_zarr(zarr_path: str, out_path: str, chunks: dict = None) -> None:
+    """Rechunk zarr store for efficient spatial access."""
+    if chunks is None:
+        chunks = {"time": 1, "y": 512, "x": 512}
+    ds = xr.open_zarr(zarr_path)
+    ds_rechunked = ds.chunk(chunks)
+
+    encoding = {}
+    for var in list(ds_rechunked.data_vars) + list(ds_rechunked.coords):
+        da = ds_rechunked[var]
+        if hasattr(da, "chunks") and da.chunks:
+            encoding[var] = {"chunks": tuple(c[0] for c in da.chunks)}
+
+    ds_rechunked.to_zarr(out_path, mode="w", encoding=encoding)
+    print(f"Rechunked zarr written to {out_path}")
+
+
+# ── EXTRA LAYERS ─────────────────────────────────────────────────────────────
+
+# Sentinel-1 C-band wavelength (m) — used for CRLB phase→displacement conversion
+S1_WAVELENGTH_M = 0.05546576
+
+
+def _crop_tif(path: str | Path, xmin: float, ymin: float, xmax: float, ymax: float) -> np.ndarray:
+    """Read and crop a GeoTIFF to the given bounding box, returning a 2-D float32 array.
+
+    nodata (0) is replaced with NaN.
+    """
+    with rasterio.open(path) as src:
+        win = from_bounds(xmin, ymin, xmax, ymax, src.transform)
+        arr = src.read(1, window=win).astype(np.float32)
+        nd = src.nodata
+    if nd is not None:
+        arr[arr == nd] = np.nan
+    else:
+        arr[arr == 0] = np.nan
+    return arr
+
+
+def _zarr_bbox(zarr_path: str) -> tuple[float, float, float, float]:
+    """Return (xmin, ymin, xmax, ymax) half-pixel-expanded bbox of the zarr store."""
+    ds = xr.open_zarr(zarr_path)
+    dx = abs(float(ds.x[1] - ds.x[0])) / 2
+    dy = abs(float(ds.y[0] - ds.y[1])) / 2
+    return (
+        float(ds.x.min()) - dx,
+        float(ds.y.min()) - dy,
+        float(ds.x.max()) + dx,
+        float(ds.y.max()) + dy,
+    )
+
+
+def _to_db(amp: np.ndarray) -> np.ndarray:
+    """Linear amplitude → dB: 20*log10(amp). Zeros and NaN → NaN."""
+    return np.where(amp > 0, 20.0 * np.log10(amp), np.nan).astype(np.float32)
+
+
+def _write_2d(zarr_path: str, name: str, data: np.ndarray, y, x, attrs: dict, chunks=(256, 256)):
+    da = xr.DataArray(data.astype(np.float32), dims=("y", "x"), coords={"y": y, "x": x}, attrs=attrs)
+    enc = {name: {"compressors": [], "chunks": chunks}}
+    da.to_dataset(name=name).to_zarr(zarr_path, mode="a", consolidated=False, encoding=enc)
+
+
+def _write_3d(zarr_path: str, name: str, data: np.ndarray, time_coords, y, x, attrs: dict, chunks=(4, 256, 256)):
+    da = xr.DataArray(
+        data.astype(np.float32), dims=("time", "y", "x"),
+        coords={"time": time_coords, "y": y, "x": x}, attrs=attrs,
+    )
+    enc = {name: {"compressors": [], "chunks": chunks}}
+    da.to_dataset(name=name).to_zarr(zarr_path, mode="a", consolidated=False, encoding=enc)
+
+
+def append_extra_layers(
+    zarr_path: str,
+    work_base: Path,
+    gslc_dir: Path,
+    gslc_glob: str = DEFAULT_GSLC_GLOB,
+    wavelength: float = S1_WAVELENGTH_M,
+) -> None:
+    """Append amplitude, CRLB, and stack quality metrics to an existing zarr store.
+
+    Layers added
+    ------------
+    3-D (time, y, x)  — time axis uses the ministack end-date from filename:
+      mean_amplitude        — amplitude of each compressed SLC (|VV|, multilooked)
+      amplitude_dispersion  — amplitude_dispersion stored inside each compressed SLC
+
+    2-D (y, x)  — derived entirely from the zarr's existing variables:
+      median_temporal_coherence    — nanmedian of temporal_coherence over time
+      median_phase_similarity      — nanmedian of phase_similarity over time
+      sum_inversion_residuals      — sum(|timeseries_inversion_residuals|) over time
+
+    3-D (time, y, x)  — aligned to zarr's full time axis:
+      crlb_rad             — Cramér–Rao lower bound, phase std (rad)
+      crlb_displacement    — CRLB expressed as displacement uncertainty (m)
+      amplitude            — per-date amplitude from original GSLC HDF5 files
+    """
+    ds = xr.open_zarr(zarr_path)
+    ny, nx = ds.sizes["y"], ds.sizes["x"]
+    y_coords = ds.y.values
+    x_coords = ds.x.values
+    zarr_dates = {str(t)[:10].replace("-", ""): t for t in ds.time.values}
+    sorted_dates = sorted(zarr_dates.keys())
+    time_coords = np.array([zarr_dates[d] for d in sorted_dates])
+    xmin, ymin, xmax, ymax = _zarr_bbox(zarr_path)
+    print(f"zarr bbox: {xmin:.0f} {ymin:.0f} {xmax:.0f} {ymax:.0f}  ({ny}x{nx})")
+
+    # ── 1. Mean amplitude & amplitude_dispersion from compressed SLC HDF5 ─────
+    # Filename: compressed_{burst}_{date_last}_{date_first}_{date_last}.h5
+    # Each compressed SLC covers [date_first, date_last].  We expand its 2-D
+    # values to every zarr date that falls within that range, so the output
+    # shares the same 315-date time axis as all other zarr variables.
+    print("\n[1/6] Mean amplitude & amplitude_dispersion from compressed SLCs...")
+    comp_slcs = sorted((work_base / "comp_slcs").glob("compressed*.h5"))
+    if not comp_slcs:
+        print("  WARNING: no compressed SLC HDF5 found, skipping.")
+    else:
+        def _comp_dates(f: Path) -> tuple[str, str]:
+            """Return (date_first, date_last) from compressed SLC filename."""
+            m = re.search(r"compressed_\S+?_\d{8}_(\d{8})_(\d{8})\.h5", f.name)
+            return (m.group(1), m.group(2)) if m else ("", "")
+
+        comp_info = [(d1, d2, f) for f in comp_slcs if "" not in (d := _comp_dates(f)) for d1, d2 in [d]]
+        comp_info.sort(key=lambda t: t[0])
+
+        # Crop indices (same for all files — shared grid)
+        with h5py.File(comp_info[0][2]) as h:
+            xc = h["data/x_coordinates"][:]   # 5 m spacing
+            yc = h["data/y_coordinates"][:]   # 10 m spacing
+        xi = np.where((xc >= xmin) & (xc <= xmax))[0]
+        yi = np.where((yc >= ymin) & (yc <= ymax))[0]
+        xi_s, xi_e = int(xi[0]), int(xi[-1]) + 1
+        yi_s, yi_e = int(yi[0]), int(yi[-1]) + 1
+        xi_e -= (xi_e - xi_s) % 2   # ensure even length for ×2 multilook
+
+        # Build full-time-axis arrays: each date gets the value of the ministack
+        # that contains it; last ministack wins if ranges overlap.
+        mean_amp_3d  = np.full((len(sorted_dates), ny, nx), np.nan, dtype=np.float32)
+        adisp_3d     = np.full((len(sorted_dates), ny, nx), np.nan, dtype=np.float32)
+
+        for date_first, date_last, f in comp_info:
+            with h5py.File(f) as h:
+                vv    = h["data/VV"][yi_s:yi_e, xi_s:xi_e]
+                adisp = h["data/amplitude_dispersion"][yi_s:yi_e, xi_s:xi_e]
+            amp = np.abs(vv).astype(np.float32)
+            amp_ml   = (amp[:,0::2]   + amp[:,1::2])   / 2
+            adisp_ml = (adisp[:,0::2] + adisp[:,1::2]) / 2
+            adisp_ml = adisp_ml.astype(np.float32)
+            adisp_ml[adisp_ml <= 0] = np.nan
+
+            for t_idx, d in enumerate(sorted_dates):
+                if date_first <= d <= date_last:
+                    mean_amp_3d[t_idx]  = _to_db(amp_ml)[:ny, :nx]
+                    adisp_3d[t_idx]     = adisp_ml[:ny, :nx]
+
+        _write_3d(zarr_path, "mean_amplitude", mean_amp_3d, time_coords, y_coords, x_coords,
+                  {"long_name": "Compressed-SLC mean amplitude (|VV|, multilooked ×2 in x)",
+                   "units": "dB  (20*log10(linear amplitude))",
+                   "note": "constant within each ministack [date_first, date_last]"})
+        _write_3d(zarr_path, "amplitude_dispersion", adisp_3d, time_coords, y_coords, x_coords,
+                  {"long_name": "Amplitude dispersion (std/mean) from compressed SLC ministack",
+                   "note": "constant within each ministack [date_first, date_last]"})
+        print(f"  Written mean_amplitude, amplitude_dispersion  "
+              f"({len(comp_info)} ministacks → {len(sorted_dates)} time steps)")
+
+    # ── 2. Stack quality summary metrics (2-D, from zarr variables) ───────────
+    print("\n[2/6] Stack quality summary metrics (from zarr)...")
+
+    def _nanmedian_2d(da: xr.DataArray) -> np.ndarray:
+        return np.nanmedian(da.values.astype(np.float32), axis=0)
+
+    med_tc = _nanmedian_2d(ds.temporal_coherence)
+    _write_2d(zarr_path, "median_temporal_coherence", med_tc, y_coords, x_coords,
+              {"long_name": "Median temporal coherence across stack", "units": "0-1"})
+
+    med_ps = _nanmedian_2d(ds.phase_similarity)
+    _write_2d(zarr_path, "median_phase_similarity", med_ps, y_coords, x_coords,
+              {"long_name": "Median phase similarity across stack", "units": "0-1"})
+
+    sum_res = np.nansum(np.abs(ds.timeseries_inversion_residuals.values.astype(np.float32)), axis=0)
+    sum_res[sum_res == 0] = np.nan
+    _write_2d(zarr_path, "sum_inversion_residuals", sum_res, y_coords, x_coords,
+              {"long_name": "Sum of absolute timeseries inversion residuals", "units": "rad"})
+
+    print("  Written median_temporal_coherence, median_phase_similarity, sum_inversion_residuals")
+
+    # ── 3. CRLB (time, y, x) ─────────────────────────────────────────────────
+    print("\n[3/6] CRLB (phase std in rad + displacement uncertainty)...")
+
+    # Collect one crlb file per date, preferring later batches when date repeats
+    # (later batches use more data → better estimate)
+    # Glob batch_*/*/linked_phase/ to be agnostic about the burst directory name.
+    date_to_crlb: dict[str, Path] = {}
+    for batch_dir in sorted(work_base.glob("batch_*/*/linked_phase/")):
+        for ms_dir in sorted(batch_dir.iterdir()):
+            if not ms_dir.is_dir():
+                continue
+            for cf in sorted((ms_dir / "crlb").glob("crlb_*.tif")):
+                m = re.search(r"crlb_(\d{8})\.tif", cf.name)
+                if m:
+                    date_to_crlb[m.group(1)] = cf   # last batch wins
+
+    # Build time-ordered arrays aligned to zarr time axis
+    crlb_rad   = np.full((len(zarr_dates), ny, nx), np.nan, dtype=np.float32)
+    for t_idx, (date_str, _) in enumerate(sorted(zarr_dates.items())):
+        cf = date_to_crlb.get(date_str)
+        if cf is None:
+            continue
+        # CRLB tif stores std in rad directly (dolphin _crlb_from_x returns sqrt(diag(Sigma)))
+        arr = _crop_tif(cf, xmin, ymin, xmax, ymax)
+        crlb_rad[t_idx] = arr[:ny, :nx]
+
+    _write_3d(zarr_path, "crlb_rad", crlb_rad, time_coords, y_coords, x_coords,
+              {"long_name": "Cramér-Rao lower bound — phase std", "units": "rad"})
+
+    # Convert to displacement uncertainty: sigma_d = (wavelength / 4π) * sigma_phi
+    factor = wavelength / (4 * np.pi)
+    crlb_disp = crlb_rad * factor
+    _write_3d(zarr_path, "crlb_displacement", crlb_disp, time_coords, y_coords, x_coords,
+              {"long_name": "Cramér-Rao lower bound — displacement uncertainty", "units": "m",
+               "wavelength_m": wavelength, "conversion": "wavelength / (4*pi) * crlb_rad"})
+    print(f"  Written crlb_rad, crlb_displacement ({sum(v is not None for v in [date_to_crlb.get(d) for d in zarr_dates])} dates matched)")
+
+    # ── 4. Per-date amplitude (dB) + stack amplitude dispersion from GSLC ──────
+    print("\n[4/6] Per-date amplitude (dB) from GSLC HDF5...")
+
+    date_to_gslc: dict[str, Path] = {}
+    for f in sorted(gslc_dir.rglob(gslc_glob)):
+        m = re.search(r"_(\d{8})\.h5$", f.name)
+        if m:
+            date_to_gslc[m.group(1)] = f
+
+    ref_gslc = next(iter(date_to_gslc.values()))
+    with h5py.File(ref_gslc) as h:
+        xg = h["data/x_coordinates"][:]
+        yg = h["data/y_coordinates"][:]
+    xgi = np.where((xg >= xmin) & (xg <= xmax))[0]
+    ygi = np.where((yg >= ymin) & (yg <= ymax))[0]
+    xgi_s, xgi_e = int(xgi[0]), int(xgi[-1]) + 1
+    ygi_s, ygi_e = int(ygi[0]), int(ygi[-1]) + 1
+    xgi_e -= (xgi_e - xgi_s) % 2
+
+    amplitude = np.full((len(sorted_dates), ny, nx), np.nan, dtype=np.float32)
+
+    matched = 0
+    for t_idx, date_str in enumerate(sorted_dates):
+        gf = date_to_gslc.get(date_str)
+        if gf is None:
+            continue
+        with h5py.File(gf) as h:
+            vv = h["data/VV"][ygi_s:ygi_e, xgi_s:xgi_e]
+        amp = np.abs(vv).astype(np.float32)
+        amp_ml = (amp[:, 0::2] + amp[:, 1::2]) / 2
+        amplitude[t_idx] = _to_db(amp_ml)[:ny, :nx]
+        matched += 1
+
+    _write_3d(zarr_path, "amplitude", amplitude, time_coords, y_coords, x_coords,
+              {"long_name": "Per-date amplitude from GSLC (multilook ×2 in x)",
+               "units": "dB  (20*log10(linear amplitude))"})
+    print(f"  Written amplitude (dB) ({matched}/{len(sorted_dates)} dates matched)")
+
+    # ── 5. Stack amplitude dispersion + mean amplitude dB from zarr (2-D) ──────
+    # Re-open zarr to read the amplitude we just wrote (dB).
+    # All stats computed in linear space; mean amplitude also stored in dB.
+    print("\n[5/6] Stack amplitude dispersion + mean amplitude dB from zarr...")
+    ds2 = xr.open_zarr(zarr_path)
+    amp_db = ds2["amplitude"].values.astype(np.float32)        # (time, y, x)
+    amp_lin = np.where(np.isfinite(amp_db), 10.0 ** (amp_db / 20.0), np.nan)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        amp_mean_lin = np.nanmean(amp_lin, axis=0)
+        amp_std      = np.nanstd(amp_lin, axis=0, ddof=1)
+        stack_amp_disp = np.where(amp_mean_lin > 0, amp_std / amp_mean_lin, np.nan)
+        amp_mean_db    = np.where(amp_mean_lin > 0, 20.0 * np.log10(amp_mean_lin), np.nan)
+
+    _write_2d(zarr_path, "mean_amplitude_db", amp_mean_db.astype(np.float32),
+              y_coords, x_coords,
+              {"long_name": "Time-mean amplitude from full GSLC stack",
+               "units": "dB  (20*log10(mean linear amplitude))",
+               "note": f"mean computed in linear space, then converted to dB ({matched} dates)"})
+    _write_2d(zarr_path, "stack_amplitude_dispersion", stack_amp_disp.astype(np.float32),
+              y_coords, x_coords,
+              {"long_name": "Amplitude dispersion from full GSLC stack (std/mean, linear)",
+               "units": "dimensionless",
+               "note": f"computed from zarr amplitude variable ({matched} dates)"})
+    print(f"  Written mean_amplitude_db (mean={np.nanmean(amp_mean_db):.1f} dB)")
+    print(f"  Written stack_amplitude_dispersion (mean={np.nanmean(stack_amp_disp):.3f})")
+
+    # ── 6. Consolidate ────────────────────────────────────────────────────────
+    print("\n[6/6] Consolidating zarr metadata...")
+    zarr.consolidate_metadata(zarr_path)
+    print("Done — extra layers appended and metadata consolidated.")
+
+
+# ── MAIN ──────────────────────────────────────────────────────────────────────
+
+STAGES = ("process", "reformat", "velocity", "extra")
+
+
+def run_processing(
+    cslc_dir: Path,
+    work_base: Path,
+    frame_id: int,
+    extent: str,
+    *,
+    ms_size: int,
+    max_comp: int,
+    buffer: float,
+    gpu: bool,
+    gslc_glob: str,
+    forward_window: int = DEFAULT_FORWARD_WINDOW,
+) -> None:
+    """Stage 1: run disp_s1 per batch with compressed carry-forward.
+
+    Full ministacks of ``ms_size`` real SLCs run in HISTORICAL mode (each saving
+    one compressed SLC). Every remaining date that cannot fill a full ministack
+    then runs in FORWARD mode as its own job, with a fixed input stack of
+    ``1 compressed SLC + forward_window real SLCs`` ending at that date
+    (e.g. n-4, n-3, n-2, n-1, n for forward_window=5). Each forward run yields
+    exactly one product (date n), so no dates are dropped.
+    """
+    # ── Discover CSLCs ────────────────────────────────────────────────────────
+    files = sorted(cslc_dir.rglob(gslc_glob))
+    if not files:
+        raise SystemExit(f"No files matching {gslc_glob!r} under {cslc_dir}")
+    burst_to_cslc = group_by_burst(files)
+    burst_ids = sorted(burst_to_cslc)
+    n_bursts = len(burst_ids)
+    reals_by_burst = {b: sorted(burst_to_cslc[b]) for b in burst_ids}
+    # Number of acquisition dates common to all bursts (indices align across bursts).
+    n_dates = min(len(v) for v in reals_by_burst.values())
+
+    n_hist = n_dates // ms_size          # full historical ministacks
+    hist_count = n_hist * ms_size        # real dates consumed by historical
+    n_forward = n_dates - hist_count     # leftover dates → one forward run each
+    print(
+        f"{n_bursts} burst(s), {n_dates} date(s): {n_hist} historical ministack(s) "
+        f"of {ms_size} + {n_forward} forward product(s), {len(files)} total CSLCs"
+    )
+    if n_hist == 0:
+        raise SystemExit(
+            f"Only {n_dates} date(s) (< ministack size {ms_size}); need at least one "
+            "full historical ministack to bootstrap compressed SLCs for forward mode."
+        )
+
+    # ── Spatial subset ────────────────────────────────────────────────────────
+    minx, miny, maxx, maxy, epsg = extent_to_projected_bbox(extent, files[0])
+    print(f"bbox (EPSG:{epsg}): {minx:.0f} {miny:.0f} {maxx:.0f} {maxy:.0f}")
+    bounds = [minx - buffer, miny - buffer, maxx + buffer, maxy + buffer]
+
+    # ── Shared compressed SLC store ───────────────────────────────────────────
+    comp_slc_dir = work_base / "comp_slcs"
+    comp_slc_dir.mkdir(parents=True, exist_ok=True)
+
+    amp_disp_files: list[Path] = []
+    amp_mean_files: list[Path] = []
+
+    def _pick_comp(k: int) -> list[Path]:
+        """Latest ``k`` compressed SLCs per burst from the shared store."""
+        stored = sorted(comp_slc_dir.glob("*.h5")) or sorted(comp_slc_dir.glob("*.tif"))
+        picked: list[Path] = []
+        for burst_files in group_by_burst(stored).values():
+            picked.extend(sorted(burst_files)[-k:])
+        return sorted(picked)
+
+    def _run_batch(batch_cslcs, comp_slc_files, work_dir, output_dir, mode):
+        """Build cfg + runconfig and run one disp_s1 batch (historical or forward)."""
+        n_real = len(batch_cslcs) // n_bursts
+        num_ccslc = len(comp_slc_files) // n_bursts
+        work_dir.mkdir(parents=True, exist_ok=True)
+        cfg = make_cfg(
+            cslc_files=batch_cslcs,
+            work_dir=work_dir,
+            comp_slc_files=comp_slc_files,
+            amp_disp_files=amp_disp_files,
+            amp_mean_files=amp_mean_files,
+            gpu=gpu,
+            bounds=bounds,
+            epsg=epsg,
+            compressed_slc_plan=CompressedSlcPlan.LAST_PER_MINISTACK,
+            output_reference_idx=max(0, num_ccslc - 1),
+            ministack_size=num_ccslc + n_real + 1,
+        )
+        pge_rc = make_pge_runconfig(
+            cfg=cfg,
+            frame_id=frame_id,
+            mode=mode,
+            work_dir=work_dir,
+            output_dir=output_dir,
+            save_compressed_slc=(mode == ProcessingMode.HISTORICAL),
+        )
+        run_no_corrections(cfg, pge_rc)
+
+    def _harvest_compressed(output_dir, work_dir) -> None:
+        """Copy compressed SLCs produced by a historical run into the shared store."""
+        comp_out = output_dir / "compressed_slcs"
+        new_comp = sorted(comp_out.glob("*.h5")) if comp_out.exists() else []
+        if not new_comp:
+            new_comp = sorted(work_dir.rglob("linked_phase/compressed_*.tif"))
+        for src in new_comp:
+            dst = comp_slc_dir / src.name
+            if not dst.exists():
+                shutil.copy2(src, dst)
+
+    run_idx = 0
+
+    # ── Historical ministacks (full ms_size groups) ───────────────────────────
+    for ms_i in range(n_hist):
+        s, e = ms_i * ms_size, (ms_i + 1) * ms_size
+        batch_cslcs = [f for b in burst_ids for f in reals_by_burst[b][s:e]]
+        comp_slc_files = _pick_comp(max_comp)
+        work_dir = work_base / f"batch_{run_idx:03d}_historical"
+        output_dir = work_base / f"output_{run_idx:03d}"
+
+        print(f"\n{'='*60}")
+        print(
+            f"[historical {ms_i + 1}/{n_hist}] date idx {s}-{e - 1}  "
+            f"reals={len(batch_cslcs)}  ccslc_in={len(comp_slc_files)}"
+        )
+        _run_batch(batch_cslcs, comp_slc_files, work_dir, output_dir,
+                   ProcessingMode.HISTORICAL)
+        _harvest_compressed(output_dir, work_dir)
+
+        new_amp_disp = sorted(work_dir.rglob("*_amp_dispersion.tif"))
+        new_amp_mean = sorted(work_dir.rglob("*_amp_mean.tif"))
+        if new_amp_disp:
+            amp_disp_files = new_amp_disp
+        if new_amp_mean:
+            amp_mean_files = new_amp_mean
+        print(f"  → compressed store: {len(_pick_comp(max_comp))} (latest {max_comp}/burst)")
+        run_idx += 1
+
+    # ── Forward products (one run per leftover date) ──────────────────────────
+    # Each forward run: 1 compressed SLC + `forward_window` reals ending at date n.
+    # run_no_corrections keeps only the newest date's product, so one product/run.
+    for k, n in enumerate(range(hist_count, n_dates)):
+        s = max(0, n - (forward_window - 1))
+        batch_cslcs = [f for b in burst_ids for f in reals_by_burst[b][s:n + 1]]
+        comp_fwd = _pick_comp(1)  # exactly 1 ccslc per burst
+        if not comp_fwd:
+            raise SystemExit("No compressed SLC available for forward mode.")
+        work_dir = work_base / f"batch_{run_idx:03d}_forward"
+        output_dir = work_base / f"output_{run_idx:03d}"
+
+        print(f"\n{'='*60}")
+        print(
+            f"[forward {k + 1}/{n_forward}] product date idx {n}  "
+            f"window reals idx {s}-{n} ({len(batch_cslcs)} files)  "
+            f"ccslc={len(comp_fwd)}"
+        )
+        _run_batch(batch_cslcs, comp_fwd, work_dir, output_dir,
+                   ProcessingMode.FORWARD)
+        run_idx += 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Command-line interface for the DISP-S1 processing pipeline."""
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    # ── Required, site-specific ──
+    p.add_argument(
+        "--cslc-dir",
+        type=Path,
+        required=True,
+        help="Directory of input (G)SLC burst HDF5 files (searched recursively).",
+    )
+    p.add_argument(
+        "--work-dir",
+        type=Path,
+        required=True,
+        help="Output/scratch directory for batches, products, and the zarr store.",
+    )
+    p.add_argument("--frame-id", type=int, required=True, help="OPERA frame id.")
+    p.add_argument(
+        "--extent",
+        required=True,
+        help="Spatial subset as 'minlon,minlat : maxlon,maxlat' (WGS84).",
+    )
+    # ── Optional processing knobs ──
+    p.add_argument(
+        "-ms", "--ministack-size", type=int, default=DEFAULT_MS_SIZE,
+        help="Number of acquisitions per ministack.",
+    )
+    p.add_argument(
+        "--num-compressed", type=int, default=DEFAULT_MAX_COMP,
+        help="Compressed SLCs carried forward per burst (historical).",
+    )
+    p.add_argument(
+        "--forward-window", type=int, default=DEFAULT_FORWARD_WINDOW,
+        help="Real SLCs per forward run (window ending at the product date, e.g. "
+             "5 → n-4,n-3,n-2,n-1,n). Each forward run also uses 1 compressed SLC.",
+    )
+    p.add_argument(
+        "--buffer", type=float, default=DEFAULT_BUFFER,
+        help="Padding (metres) added around the extent bbox.",
+    )
+    p.add_argument("--gpu", action="store_true", help="Enable GPU (JAX) processing.")
+    p.add_argument(
+        "--gslc-glob", default=DEFAULT_GSLC_GLOB,
+        help="Glob for (G)SLC HDF5 files under --cslc-dir (any burst id by default).",
+    )
+    p.add_argument(
+        "--zarr-out", type=Path, default=None,
+        help="Output zarr path (default: <work-dir>/disp.zarr).",
+    )
+    p.add_argument(
+        "--reference-coherence-threshold", type=float, default=0.7,
+        help="Coherence threshold for HIGH_COHERENCE reference selection.",
+    )
+    p.add_argument(
+        "--weight-by-coherence", action="store_true",
+        help="Weight the velocity fit by average temporal coherence.",
+    )
+    p.add_argument(
+        "--stages", nargs="+", choices=STAGES, default=list(STAGES),
+        help="Which pipeline stages to run (default: all). Later stages reuse "
+             "existing outputs, so you can re-run e.g. only 'velocity extra'.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = build_parser().parse_args(argv)
+
+    work_base: Path = args.work_dir
+    work_base.mkdir(parents=True, exist_ok=True)
+    zarr_out = args.zarr_out or (work_base / "disp.zarr")
+
+    # Stage scratch inside the work dir (JPL /tmp is tiny — keep off it).
+    os.environ["TMPDIR"] = str(work_base)
+
+    if "process" in args.stages:
+        run_processing(
+            cslc_dir=args.cslc_dir,
+            work_base=work_base,
+            frame_id=args.frame_id,
+            extent=args.extent,
+            ms_size=args.ministack_size,
+            max_comp=args.num_compressed,
+            buffer=args.buffer,
+            gpu=args.gpu,
+            gslc_glob=args.gslc_glob,
+            forward_window=args.forward_window,
+        )
+
+    if "reformat" in args.stages:
+        print("\n" + "=" * 60)
+        print("Reformatting outputs to zarr...")
+        input_files = sorted(work_base.glob("output_*/20*.nc"))
+        if not input_files:
+            raise SystemExit(
+                f"No per-ministack .nc outputs found under {work_base}/output_*/"
+            )
+        reformat_stack_custom(
+            input_files=input_files,
+            output_name=str(zarr_out),
+            apply_solid_earth_corrections=False,
+            apply_ionospheric_corrections=False,
+            quality_datasets=None,
+            quality_thresholds=None,
+            reference_method=ReferenceMethod.HIGH_COHERENCE,
+            reference_coherence_threshold=args.reference_coherence_threshold,
+            out_chunks=(4, 256, 256),
+        )
+
+    if "velocity" in args.stages:
+        print("\nEstimating velocity...")
+        add_velocity_to_zarr(str(zarr_out), weight_by_coherence=args.weight_by_coherence)
+
+    if "extra" in args.stages:
+        print("\nAppending extra layers...")
+        append_extra_layers(
+            zarr_path=str(zarr_out),
+            work_base=work_base,
+            gslc_dir=args.cslc_dir,
+            gslc_glob=args.gslc_glob,
+        )
+
+    print("\nAll done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/disp_s1_process.py
+++ b/scripts/disp_s1_process.py
@@ -38,6 +38,7 @@ from collections.abc import Sequence
 from dataclasses import asdict
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import h5py
 import numpy as np
@@ -87,6 +88,9 @@ from disp_s1.pge_runconfig import (
     StaticAncillaryFileGroup,
 )
 
+if TYPE_CHECKING:
+    from opera_utils.disp._enums import ReferenceMethod
+
 # NOTE: the whole `opera_utils.disp` subpackage (and rioxarray) is imported lazily
 # inside reformat_stack_custom so the `process` stage can run in environments that
 # lack the reformat toolchain (e.g. disp-patch-env without rioxarray).
@@ -112,12 +116,13 @@ def make_cfg(
     amp_disp_files: list[Path],
     amp_mean_files: list[Path],
     epsg=None,
-    bounds: list = None,
+    bounds: list | None = None,
     gpu: bool = False,
     compressed_slc_plan: CompressedSlcPlan = CompressedSlcPlan.LAST_PER_MINISTACK,
-    output_reference_idx: int = None,
+    output_reference_idx: int | None = None,
     ministack_size: int = DEFAULT_MS_SIZE,
 ) -> DisplacementWorkflow:
+    """Build a `DisplacementWorkflow` config for one ministack batch."""
     return DisplacementWorkflow(
         cslc_file_list=comp_slc_files + cslc_files,
         input_options=InputOptions(subdataset=OPERA_DATASET_NAME),
@@ -177,6 +182,7 @@ def make_pge_runconfig(
     output_dir: Path,
     save_compressed_slc: bool = True,
 ) -> RunConfig:
+    """Build a PGE `RunConfig` wrapping the dolphin workflow config."""
     alg_params_file = work_dir / "algorithm_parameters.yaml"
     algo_keys = set(AlgorithmParameters.model_fields.keys())
     alg_params = AlgorithmParameters(
@@ -209,7 +215,7 @@ def make_pge_runconfig(
 
 
 def extent_to_projected_bbox(extent_str: str, gslc_file: Path):
-    """Convert 'minlon,minlat : maxlon,maxlat' extent to projected bbox from GSLC CRS."""
+    """Convert 'minlon,minlat : maxlon,maxlat' extent to a projected bbox."""
     left, right = extent_str.split(" : ")
     minlon, minlat = map(float, left.split(","))
     maxlon, maxlat = map(float, right.split(","))
@@ -325,7 +331,7 @@ def run_no_corrections(
 
         out_paths_with_corr = OutputPathsWithCorrections(
             **asdict(out_paths),
-            ionospheric_corrections=None,
+            ionospheric_corrections=[],
         )
 
         create_products(
@@ -607,7 +613,7 @@ def add_velocity_to_zarr(zarr_path: str, weight_by_coherence: bool = True) -> No
 # ── RECHUNK ───────────────────────────────────────────────────────────────────
 
 
-def rechunk_zarr(zarr_path: str, out_path: str, chunks: dict = None) -> None:
+def rechunk_zarr(zarr_path: str, out_path: str, chunks: dict | None = None) -> None:
     """Rechunk zarr store for efficient spatial access."""
     if chunks is None:
         chunks = {"time": 1, "y": 512, "x": 512}
@@ -754,8 +760,8 @@ def append_extra_layers(
         comp_info = [
             (d1, d2, f)
             for f in comp_slcs
-            if "" not in (d := _comp_dates(f))
-            for d1, d2 in [d]
+            if "" not in (date_pair := _comp_dates(f))
+            for d1, d2 in [date_pair]
         ]
         comp_info.sort(key=lambda t: t[0])
 
@@ -886,11 +892,11 @@ def append_extra_layers(
     # Build time-ordered arrays aligned to zarr time axis
     crlb_rad = np.full((len(zarr_dates), ny, nx), np.nan, dtype=np.float32)
     for t_idx, (date_str, _) in enumerate(sorted(zarr_dates.items())):
-        cf = date_to_crlb.get(date_str)
-        if cf is None:
+        crlb_file = date_to_crlb.get(date_str)
+        if crlb_file is None:
             continue
-        # CRLB tif stores std in rad directly (dolphin _crlb_from_x returns sqrt(diag(Sigma)))
-        arr = _crop_tif(cf, xmin, ymin, xmax, ymax)
+        # CRLB tif stores std in rad (dolphin _crlb_from_x returns sqrt(diag(Sigma)))
+        arr = _crop_tif(crlb_file, xmin, ymin, xmax, ymax)
         crlb_rad[t_idx] = arr[:ny, :nx]
 
     _write_3d(
@@ -1278,6 +1284,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> None:
+    """Run the standalone DISP-S1 processing pipeline from the CLI."""
     args = build_parser().parse_args(argv)
 
     work_base: Path = args.work_dir

--- a/scripts/recompute_bperp_bbounds.py
+++ b/scripts/recompute_bperp_bbounds.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+"""Recompute the perpendicular baseline AND the bounding polygon in one pass.
+
+Combines the two single-purpose scripts into one, updating both layers of an
+OPERA DISP-S1 NetCDF in a single output file:
+
+  - ``recompute_perpendicular_baseline.py`` -> /corrections/perpendicular_baseline
+    (recomputed from the saved reference/secondary orbits)
+  - ``recompute_product_bounds.py``         -> /identification/bounding_polygon
+    (minimum rotated rectangle of the valid-data footprint, via the shared
+    ``disp_s1._utils.extract_footprint`` used in forward production)
+
+The input is copied to the output once, both layers are rewritten, and the
+metadata timestamps / version are updated a single time at the end.
+
+Example
+-------
+    $ python scripts/recompute_bperp_bbounds.py input.nc -o output.nc
+
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+
+import h5py
+import tyro
+
+from recompute_perpendicular_baseline import recompute_perpendicular_baseline
+from recompute_product_bounds import (
+    BOUNDING_POLYGON_PATH,
+    compute_bounding_polygon,
+    update_metadata_timestamps,
+)
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def recompute_bperp_bbounds(
+    input_file: Path,
+    output_file: Path | None = None,
+    subsample: int = 50,
+    update_metadata: bool = True,
+    update_version: bool = False,
+    new_version: str | None = None,
+) -> Path:
+    """Recompute perpendicular baseline + bounding polygon and update the NetCDF.
+
+    Parameters
+    ----------
+    input_file : Path
+        Path to the input OPERA DISP-S1 NetCDF file.
+    output_file : Path, optional
+        Path to the output file. If not provided, adds a "_corrected" suffix.
+    subsample : int
+        Subsampling factor for the perpendicular-baseline computation.
+        Default = 50
+    update_metadata : bool
+        Whether to update the processing_start_datetime field.
+        Default = True
+    update_version : bool
+        Whether to update the product version field.
+        Default = False
+    new_version : str, optional
+        New version string to replace in /identification/product_version.
+        Required if update_version=True.
+
+    Returns
+    -------
+    Path
+        Path to the output file.
+
+    """
+    input_file = Path(input_file)
+    if output_file is None:
+        output_file = input_file.with_stem(f"{input_file.stem}_corrected")
+    output_file = Path(output_file)
+
+    # 1) Perpendicular baseline. This copies input -> output and rewrites
+    #    /corrections/perpendicular_baseline. Defer the metadata/version bump to
+    #    the single update at the end so it is not applied twice.
+    logger.info("=== Recomputing perpendicular baseline ===")
+    recompute_perpendicular_baseline(
+        input_file,
+        output_file,
+        subsample=subsample,
+        update_metadata=False,
+        update_version=False,
+    )
+
+    # 2) Bounding polygon, recomputed from the (untouched) displacement layer.
+    logger.info("=== Recomputing bounding polygon ===")
+    footprint_wkt = compute_bounding_polygon(input_file)
+    with h5py.File(output_file, "a") as f:
+        old_polygon = f[BOUNDING_POLYGON_PATH][()].decode("utf-8")
+        logger.info(f"Updating {BOUNDING_POLYGON_PATH}")
+        logger.info(f"  old: {old_polygon}")
+        logger.info(f"  new: {footprint_wkt}")
+        f[BOUNDING_POLYGON_PATH][()] = footprint_wkt.encode("utf-8")
+
+    # 3) Single metadata / version update covering both edits.
+    logger.info("Updating metadata timestamps")
+    update_metadata_timestamps(
+        output_file,
+        processing_datetime=datetime.now(),
+        update_processing_time=update_metadata,
+        update_version=update_version,
+        new_version=new_version,
+    )
+
+    logger.info(
+        f"Successfully recomputed baseline + bounding polygon -> {output_file}"
+    )
+    return output_file
+
+
+if __name__ == "__main__":
+    tyro.cli(recompute_bperp_bbounds)

--- a/scripts/recompute_bperp_bbounds.py
+++ b/scripts/recompute_bperp_bbounds.py
@@ -13,7 +13,7 @@ OPERA DISP-S1 NetCDF in a single output file:
 The input is copied to the output once, both layers are rewritten, and the
 metadata timestamps / version are updated a single time at the end.
 
-Example
+Example:
 -------
     $ python scripts/recompute_bperp_bbounds.py input.nc -o output.nc
 
@@ -27,7 +27,6 @@ from pathlib import Path
 
 import h5py
 import tyro
-
 from recompute_perpendicular_baseline import recompute_perpendicular_baseline
 from recompute_product_bounds import (
     BOUNDING_POLYGON_PATH,
@@ -111,9 +110,7 @@ def recompute_bperp_bbounds(
         new_version=new_version,
     )
 
-    logger.info(
-        f"Successfully recomputed baseline + bounding polygon -> {output_file}"
-    )
+    logger.info(f"Successfully recomputed baseline + bounding polygon -> {output_file}")
     return output_file
 
 

--- a/scripts/recompute_product_bounds.py
+++ b/scripts/recompute_product_bounds.py
@@ -33,9 +33,10 @@ from pathlib import Path
 import h5py
 import numpy as np
 import tyro
-from disp_s1._utils import extract_footprint
 from dolphin import io
 from pyproj import CRS
+
+from disp_s1._utils import extract_footprint
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -85,8 +86,14 @@ def compute_bounding_polygon(input_file: Path) -> str:
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         mask_tif = Path(tmp_dir) / "valid_mask.tif"
-        io.write_arr(arr=mask, output_name=mask_tif, geotransform=geotransform,
-                     projection=crs.to_wkt(), dtype="uint8", nodata=0)
+        io.write_arr(
+            arr=mask,
+            output_name=mask_tif,
+            geotransform=geotransform,
+            projection=crs.to_wkt(),
+            dtype="uint8",
+            nodata=0,
+        )
         return extract_footprint(mask_tif)
 
 

--- a/scripts/recompute_product_bounds.py
+++ b/scripts/recompute_product_bounds.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python
+"""Recompute the bounding polygon of an OPERA DISP-S1 product.
+
+The bounding polygon stored in some DISP-S1 products does not match the actual
+extent of the valid displacement data (see opera-sds nasa/disp-s1#376). This
+script recomputes the footprint directly from the `displacement` layer:
+
+  1. Build a validity mask of the displacement data (finite and non-zero).
+  2. Write the mask to a temporary GeoTIFF in the product's CRS.
+  3. Run `disp_s1._utils.extract_footprint` — the same function used to write the
+     bounding polygon during forward product generation — to get the minimum
+     rotated rectangle of the valid-data footprint (antimeridian-split).
+  4. Write the result back into the product metadata:
+       /identification/bounding_polygon  (WKT, degrees)
+
+Using `extract_footprint` keeps this retroactive fix byte-for-byte consistent
+with forward processing.
+
+Example:
+-------
+    $ python scripts/recompute_product_bounds.py input.nc -o output.nc
+
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+import h5py
+import numpy as np
+import tyro
+from disp_s1._utils import extract_footprint
+from dolphin import io
+from pyproj import CRS
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+DISPLACEMENT_DATASET = "displacement"
+BOUNDING_POLYGON_PATH = "/identification/bounding_polygon"
+
+
+def compute_bounding_polygon(input_file: Path) -> str:
+    """Recompute the bounding polygon from a product's ``/displacement`` layer.
+
+    Writes the valid-data mask to a temporary GeoTIFF and runs the shared
+    ``disp_s1._utils.extract_footprint`` (the same call used in forward product
+    generation), returning the minimum rotated rectangle of the footprint as an
+    EPSG:4326 MULTIPOLYGON WKT.
+
+    Notes
+    -----
+    The displacement is read with h5py rather than ``dolphin.io.load_gdal`` on
+    purpose. Forward processing runs ``extract_footprint`` on the GeoTIFF timeseries,
+    but this script reads ``/displacement`` back from the NetCDF.
+    GDAL flips the NetCDF y-axis (gdal 3.12.3 reads it reversed relative
+    to the stored /y axis; 3.12.2 does not) while leaving GeoTIFFs untouched, so
+    a ``load_gdal`` read would disagree with forward output.
+    Reading natively with h5py (CF ``(y, x)`` layout, where
+    ``/displacement[i, j]`` maps to ``/y[i]``, ``/x[j]``) is what keeps the
+    recompute consistent with forward production and independent of GDAL's
+    NetCDF orientation behavior. The mask is then written to a GeoTIFF, which
+    GDAL reads unambiguously, before calling ``extract_footprint``.
+
+    """
+    logger.info(f"Reading displacement from {input_file}")
+    with h5py.File(input_file) as f:
+        disp = f[f"/{DISPLACEMENT_DATASET}"][:]
+        x = f["/x"][:]
+        y = f["/y"][:]
+        crs = CRS.from_wkt(f["/spatial_ref"].attrs["crs_wkt"])
+
+    # Valid-data mask -> temp GeoTIFF -> shared extract_footprint. Same idea as
+    # `disp_s1.main._create_nodata_mask` (nonzero -> write_arr); the array is read
+    # with h5py and georeferenced from the native /x, /y axes (see Notes).
+    mask = (np.isfinite(disp) & (disp != 0)).astype("uint8")
+    if not mask.any():
+        raise ValueError(f"{input_file}: no valid displacement pixels found")
+    dx, dy = float(x[1] - x[0]), float(y[1] - y[0])
+    geotransform = (float(x[0]) - dx / 2, dx, 0.0, float(y[0]) - dy / 2, 0.0, dy)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        mask_tif = Path(tmp_dir) / "valid_mask.tif"
+        io.write_arr(arr=mask, output_name=mask_tif, geotransform=geotransform,
+                     projection=crs.to_wkt(), dtype="uint8", nodata=0)
+        return extract_footprint(mask_tif)
+
+
+def update_metadata_timestamps(
+    output_file: Path,
+    processing_datetime: datetime | None = None,
+    update_processing_time: bool = True,
+    update_version: bool = False,
+    new_version: str | None = None,
+) -> None:
+    """Update metadata timestamps in the corrected file.
+
+    Parameters
+    ----------
+    output_file : Path
+        Path to the output file to update.
+    processing_datetime : datetime, optional
+        Processing datetime to use. If None, uses current time.
+    update_processing_time : bool
+        Whether to update the processing_start_datetime field.
+        Default = True
+    update_version : bool
+        Whether to update the product version.
+    new_version : str, optional
+        New version string. If None and update_version=True, appends ".1".
+
+    """
+    if processing_datetime is None:
+        processing_datetime = datetime.now()
+
+    with h5py.File(output_file, "a") as f:
+        # Update processing_start_datetime
+        if update_processing_time:
+            old_datetime = f["/identification/processing_start_datetime"][()].decode(
+                "utf-8"
+            )
+            logger.info(
+                f"Updating processing_start_datetime from {old_datetime} to "
+                f"{processing_datetime.strftime('%Y-%m-%d %H:%M:%S')}"
+            )
+
+            proc_str = (processing_datetime.strftime("%Y-%m-%d %H:%M:%S")).encode(
+                "utf-8"
+            )
+            f["/identification/processing_start_datetime"][()] = proc_str
+
+        # Optionally update product version
+        if update_version:
+            if new_version is None:
+                raise ValueError("new_version must be specified if update_version=True")
+
+            old_version = f["/identification/product_version"][()].decode("utf-8")
+            logger.info(f"Updating product_version from {old_version} to {new_version}")
+            f["/identification/product_version"][()] = new_version.encode("utf-8")
+
+
+def recompute_product_bounds(
+    input_file: Path,
+    output_file: Path | None = None,
+    update_metadata: bool = True,
+    update_version: bool = False,
+    new_version: str | None = None,
+) -> Path:
+    """Recompute product bounds from the displacement layer and update metadata.
+
+    Parameters
+    ----------
+    input_file : Path
+        Path to the input OPERA DISP-S1 NetCDF file.
+    output_file : Path, optional
+        Path to the output file. If not provided, will add "_corrected" suffix.
+    update_metadata : bool
+        Whether to update the processing_start_datetime field.
+        Default = True
+    update_version : bool
+        Whether to update the product version field.
+        Default = False
+    new_version : str, optional
+        New version string to replace in /identification/product_version.
+        Required if update_version=True.
+
+    Returns
+    -------
+    Path
+        Path to the output file.
+
+    """
+    input_file = Path(input_file)
+
+    if output_file is None:
+        output_file = input_file.with_stem(f"{input_file.stem}_corrected")
+
+    output_file = Path(output_file)
+
+    footprint_wkt = compute_bounding_polygon(input_file)
+
+    # Copy the input file to output so we don't overwrite the original.
+    logger.info(f"Copying {input_file} to {output_file}")
+    shutil.copy(input_file, output_file)
+
+    logger.info("Writing recomputed bounding polygon to product metadata")
+    with h5py.File(output_file, "a") as f:
+        old_polygon = f[BOUNDING_POLYGON_PATH][()].decode("utf-8")
+        logger.info(f"Updating {BOUNDING_POLYGON_PATH}")
+        logger.info(f"  old: {old_polygon}")
+        logger.info(f"  new: {footprint_wkt}")
+        f[BOUNDING_POLYGON_PATH][()] = footprint_wkt.encode("utf-8")
+
+    logger.info("Updating metadata timestamps")
+    update_metadata_timestamps(
+        output_file,
+        processing_datetime=datetime.now(),
+        update_processing_time=update_metadata,
+        update_version=update_version,
+        new_version=new_version,
+    )
+
+    logger.info(f"Successfully wrote recomputed product bounds to {output_file}")
+    return output_file
+
+
+if __name__ == "__main__":
+    tyro.cli(recompute_product_bounds)

--- a/scripts/test_recompute_bperp_bbounds.py
+++ b/scripts/test_recompute_bperp_bbounds.py
@@ -67,9 +67,7 @@ def test_baseline_recomputed(test_file, recomputed_file):
     assert np.isfinite(recomputed).any()
     # A fresh computation (here on a coarser grid) is not bit-identical to the
     # stored layer, confirming it was actually recomputed rather than copied.
-    assert not np.array_equal(
-        np.nan_to_num(original), np.nan_to_num(recomputed)
-    )
+    assert not np.array_equal(np.nan_to_num(original), np.nan_to_num(recomputed))
 
 
 def test_bounding_polygon_is_rotated_rectangle(recomputed_file):
@@ -84,9 +82,7 @@ def test_bounding_polygon_is_rotated_rectangle(recomputed_file):
 def test_displacement_preserved(test_file, recomputed_file):
     """The displacement layer is untouched by the combined recompute."""
     with h5py.File(test_file) as o, h5py.File(recomputed_file) as c:
-        np.testing.assert_array_equal(
-            o["/displacement"][:], c["/displacement"][:]
-        )
+        np.testing.assert_array_equal(o["/displacement"][:], c["/displacement"][:])
 
 
 def test_both_layers_updated_in_one_pass(test_file, recomputed_file):
@@ -95,9 +91,7 @@ def test_both_layers_updated_in_one_pass(test_file, recomputed_file):
         baseline_changed = not np.array_equal(
             np.nan_to_num(o[BASELINE_PATH][:]), np.nan_to_num(c[BASELINE_PATH][:])
         )
-        polygon_changed = (
-            o[BOUNDING_POLYGON_PATH][()] != c[BOUNDING_POLYGON_PATH][()]
-        )
+        polygon_changed = o[BOUNDING_POLYGON_PATH][()] != c[BOUNDING_POLYGON_PATH][()]
     assert baseline_changed and polygon_changed
 
 
@@ -105,9 +99,7 @@ def test_metadata_update(test_file, tmp_path):
     """processing_start_datetime is bumped once when update_metadata=True."""
     output_file = tmp_path / "meta.nc"
     with h5py.File(test_file) as f:
-        original_dt = f["/identification/processing_start_datetime"][()].decode(
-            "utf-8"
-        )
+        original_dt = f["/identification/processing_start_datetime"][()].decode("utf-8")
 
     recompute_bperp_bbounds(
         test_file, output_file, subsample=_SUBSAMPLE, update_metadata=True

--- a/scripts/test_recompute_bperp_bbounds.py
+++ b/scripts/test_recompute_bperp_bbounds.py
@@ -1,0 +1,122 @@
+"""Tests for the combined baseline + bounding-polygon recompute script."""
+
+import os
+import sys
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+import shapely
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from recompute_bperp_bbounds import recompute_bperp_bbounds
+from recompute_product_bounds import BOUNDING_POLYGON_PATH
+
+# Default test product (downloaded from ASF if not present locally). Override
+# with a local file via the DISP_S1_TEST_FILE environment variable.
+_DEFAULT_URL = "https://datapool.asf.alaska.edu/DISP/OPERA-S1/OPERA_L3_DISP-S1_IW_F11116_VV_20160705T140755Z_20160729T140756Z_v1.0_20250408T163512Z.nc"
+BASELINE_PATH = "/corrections/perpendicular_baseline"
+# Coarse subsample keeps the baseline computation fast in tests.
+_SUBSAMPLE = 200
+
+
+@pytest.fixture
+def test_file():
+    """Path to the test DISP-S1 file."""
+    override = os.environ.get("DISP_S1_TEST_FILE")
+    if override:
+        path = Path(override)
+        if not path.exists():
+            pytest.skip(f"DISP_S1_TEST_FILE not found: {path}")
+        return path
+
+    file = Path() / Path(_DEFAULT_URL).name
+    if not file.exists():
+        import subprocess
+
+        subprocess.run(["wget", _DEFAULT_URL], check=True)
+    return file
+
+
+@pytest.fixture(scope="module")
+def recomputed_file(tmp_path_factory):
+    """Run the combined recompute once and reuse across tests."""
+    override = os.environ.get("DISP_S1_TEST_FILE")
+    test_file = Path(override) if override else Path() / Path(_DEFAULT_URL).name
+    if not test_file.exists():
+        pytest.skip(f"Test file not found: {test_file}")
+
+    tmp_dir = tmp_path_factory.mktemp("bperp_bbounds_test")
+    output_file = tmp_dir / "test_output.nc"
+    # update_metadata=False keeps the run deterministic.
+    recompute_bperp_bbounds(
+        test_file, output_file, subsample=_SUBSAMPLE, update_metadata=False
+    )
+    return output_file
+
+
+def test_baseline_recomputed(test_file, recomputed_file):
+    """The perpendicular baseline is rewritten at full resolution (and changed)."""
+    with h5py.File(test_file) as f:
+        original = f[BASELINE_PATH][:]
+    with h5py.File(recomputed_file) as f:
+        recomputed = f[BASELINE_PATH][:]
+
+    assert recomputed.shape == original.shape
+    assert np.isfinite(recomputed).any()
+    # A fresh computation (here on a coarser grid) is not bit-identical to the
+    # stored layer, confirming it was actually recomputed rather than copied.
+    assert not np.array_equal(
+        np.nan_to_num(original), np.nan_to_num(recomputed)
+    )
+
+
+def test_bounding_polygon_is_rotated_rectangle(recomputed_file):
+    """The bounding polygon is updated to a 5-point MULTIPOLYGON rectangle."""
+    with h5py.File(recomputed_file) as f:
+        geom = shapely.from_wkt(f[BOUNDING_POLYGON_PATH][()].decode("utf-8"))
+
+    assert geom.geom_type == "MultiPolygon"
+    assert len(geom.geoms[0].exterior.coords) == 5
+
+
+def test_displacement_preserved(test_file, recomputed_file):
+    """The displacement layer is untouched by the combined recompute."""
+    with h5py.File(test_file) as o, h5py.File(recomputed_file) as c:
+        np.testing.assert_array_equal(
+            o["/displacement"][:], c["/displacement"][:]
+        )
+
+
+def test_both_layers_updated_in_one_pass(test_file, recomputed_file):
+    """A single output carries both the new baseline and the new polygon."""
+    with h5py.File(test_file) as o, h5py.File(recomputed_file) as c:
+        baseline_changed = not np.array_equal(
+            np.nan_to_num(o[BASELINE_PATH][:]), np.nan_to_num(c[BASELINE_PATH][:])
+        )
+        polygon_changed = (
+            o[BOUNDING_POLYGON_PATH][()] != c[BOUNDING_POLYGON_PATH][()]
+        )
+    assert baseline_changed and polygon_changed
+
+
+def test_metadata_update(test_file, tmp_path):
+    """processing_start_datetime is bumped once when update_metadata=True."""
+    output_file = tmp_path / "meta.nc"
+    with h5py.File(test_file) as f:
+        original_dt = f["/identification/processing_start_datetime"][()].decode(
+            "utf-8"
+        )
+
+    recompute_bperp_bbounds(
+        test_file, output_file, subsample=_SUBSAMPLE, update_metadata=True
+    )
+
+    with h5py.File(output_file) as f:
+        new_dt = f["/identification/processing_start_datetime"][()].decode("utf-8")
+    assert new_dt != original_dt
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/scripts/test_recompute_product_bounds.py
+++ b/scripts/test_recompute_product_bounds.py
@@ -1,0 +1,168 @@
+"""Tests for recomputing the bounding polygon from the displacement layer."""
+
+import os
+import sys
+from pathlib import Path
+
+import h5py
+import pytest
+import shapely
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from recompute_product_bounds import (
+    BOUNDING_POLYGON_PATH,
+    recompute_product_bounds,
+)
+
+# Default test product (downloaded from ASF if not present locally). Override
+# with a local file via the DISP_S1_TEST_FILE environment variable.
+_DEFAULT_URL = "https://datapool.asf.alaska.edu/DISP/OPERA-S1/OPERA_L3_DISP-S1_IW_F11116_VV_20160705T140755Z_20160729T140756Z_v1.0_20250408T163512Z.nc"
+
+
+@pytest.fixture
+def test_file():
+    """Path to the test DISP-S1 file."""
+    override = os.environ.get("DISP_S1_TEST_FILE")
+    if override:
+        path = Path(override)
+        if not path.exists():
+            pytest.skip(f"DISP_S1_TEST_FILE not found: {path}")
+        return path
+
+    file = Path() / Path(_DEFAULT_URL).name
+    if not file.exists():
+        import subprocess
+
+        subprocess.run(["wget", _DEFAULT_URL], check=True)
+    return file
+
+
+@pytest.fixture(scope="module")
+def recomputed_file(tmp_path_factory):
+    """Recompute the bounding polygon once and reuse across all tests."""
+    override = os.environ.get("DISP_S1_TEST_FILE")
+    test_file = Path(override) if override else Path() / Path(_DEFAULT_URL).name
+    if not test_file.exists():
+        pytest.skip(f"Test file not found: {test_file}")
+
+    tmp_dir = tmp_path_factory.mktemp("bounds_test")
+    output_file = tmp_dir / "test_output.nc"
+    # Don't update metadata in tests to keep tests deterministic
+    recompute_product_bounds(test_file, output_file, update_metadata=False)
+    return output_file
+
+
+def test_recomputed_polygon_is_valid(recomputed_file):
+    """The recomputed bounding polygon is a valid lon/lat geometry."""
+    with h5py.File(recomputed_file) as f:
+        wkt = f[BOUNDING_POLYGON_PATH][()].decode("utf-8")
+
+    geom = shapely.from_wkt(wkt)
+    assert geom.is_valid
+    assert not geom.is_empty
+    assert geom.geom_type in ("Polygon", "MultiPolygon")
+
+    # Coordinates should be in EPSG:4326 (lon/lat) range.
+    minx, miny, maxx, maxy = geom.bounds
+    assert -180.0 <= minx <= maxx <= 180.0
+    assert -90.0 <= miny <= maxy <= 90.0
+
+
+def test_minimum_rotated_rectangle_fix(recomputed_file):
+    """The default fix returns a 4-corner (rotated-rectangle) polygon."""
+    with h5py.File(recomputed_file) as f:
+        wkt = f[BOUNDING_POLYGON_PATH][()].decode("utf-8")
+
+    geom = shapely.from_wkt(wkt)
+    polygon = geom.geoms[0] if geom.geom_type == "MultiPolygon" else geom
+    # A minimum rotated rectangle has 5 exterior coords (4 unique + closing).
+    assert len(polygon.exterior.coords) == 5
+
+
+def test_polygon_covers_all_valid_pixels(test_file, recomputed_file):
+    """Every valid displacement pixel must fall inside the recomputed polygon.
+
+    This guards the orientation and simplification regressions: a y-flipped read
+    or pre-simplified hull leaves a few percent of the data outside the box.
+    """
+    import numpy as np
+    from pyproj import CRS, Transformer
+
+    with h5py.File(recomputed_file) as f:
+        polygon = shapely.from_wkt(f[BOUNDING_POLYGON_PATH][()].decode("utf-8"))
+    with h5py.File(test_file) as f:
+        disp = f["/displacement"][:]
+        x = f["/x"][:]
+        y = f["/y"][:]
+        crs = CRS.from_wkt(f["/spatial_ref"].attrs["crs_wkt"])
+
+    rows, cols = np.where(np.isfinite(disp) & (disp != 0))
+    # Subsample for speed; boundary coverage is what matters.
+    sub = slice(None, None, 25)
+    transformer = Transformer.from_crs(crs, CRS.from_epsg(4326), always_xy=True)
+    lon, lat = transformer.transform(x[cols[sub]], y[rows[sub]])
+    inside = shapely.contains(polygon, shapely.points(lon, lat))
+    assert inside.all()
+
+
+def test_recompute_preserves_data(test_file, recomputed_file):
+    """Other datasets are preserved when recomputing the bounding polygon."""
+    import numpy as np
+
+    with h5py.File(test_file) as f_orig, h5py.File(recomputed_file) as f_new:
+        assert f_orig["/x"][:].shape == f_new["/x"][:].shape
+        assert f_orig["/y"][:].shape == f_new["/y"][:].shape
+        assert "/displacement" in f_new
+        np.testing.assert_array_equal(
+            f_orig["/displacement"][:], f_new["/displacement"][:]
+        )
+
+
+def test_metadata_update(test_file, tmp_path):
+    """Test that metadata timestamps are updated correctly."""
+    output_file = tmp_path / "test_metadata.nc"
+
+    with h5py.File(test_file) as f:
+        original_datetime = f["/identification/processing_start_datetime"][()].decode(
+            "utf-8"
+        )
+        original_version = f["/identification/product_version"][()].decode("utf-8")
+
+    recompute_product_bounds(
+        test_file, output_file, update_metadata=True, update_version=False
+    )
+
+    with h5py.File(output_file) as f:
+        new_datetime = f["/identification/processing_start_datetime"][()].decode(
+            "utf-8"
+        )
+        new_version = f["/identification/product_version"][()].decode("utf-8")
+
+    assert new_datetime != original_datetime
+    assert new_version == original_version
+
+
+def test_version_update(test_file, tmp_path):
+    """Test that product version is updated correctly."""
+    output_file = tmp_path / "test_version.nc"
+
+    with h5py.File(test_file) as f:
+        original_version = f["/identification/product_version"][()].decode("utf-8")
+
+    recompute_product_bounds(
+        test_file,
+        output_file,
+        update_metadata=True,
+        update_version=True,
+        new_version="1.1",
+    )
+
+    with h5py.File(output_file) as f:
+        new_version = f["/identification/product_version"][()].decode("utf-8")
+
+    assert new_version == "1.1"
+    assert new_version != original_version
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/src/disp_s1/_log.py
+++ b/src/disp_s1/_log.py
@@ -5,6 +5,19 @@ from pathlib import Path
 from dolphin._types import Filename
 
 
+class InputValidationError(ValueError):
+    """Raised when the input CSLC stack fails a precheck.
+
+    Subclasses ``ValueError`` so existing handlers still catch it, while carrying
+    a numeric ``error_code`` for the PGE to map to a specific failure.
+    """
+
+    def __init__(self, message: str, error_code: int):
+        """Build the error, prefixing the message with its numeric code."""
+        super().__init__(f"[error {error_code}] {message}")
+        self.error_code = error_code
+
+
 def setup_file_logging(filename: Filename) -> None:
     """Redirect all logging to a file."""
     logger = logging.getLogger()

--- a/src/disp_s1/_utils.py
+++ b/src/disp_s1/_utils.py
@@ -187,7 +187,7 @@ def extract_footprint(raster_path: PathOrStr, simplify_tolerance: float = 0.0) -
     Notes
     -----
     This function uses GDAL to open the raster and extract the footprint,
-    and Shapely to process the geometry. 
+    and Shapely to process the geometry.
 
 
     """
@@ -206,7 +206,7 @@ def extract_footprint(raster_path: PathOrStr, simplify_tolerance: float = 0.0) -
         simplify=simplify_tolerance,
     )
 
-    # Get rectangular footprint 
+    # Get rectangular footprint
     footprint_geom = shapely.from_wkt(wkt).minimum_rotated_rectangle
 
     # Split on antimeridian and return the WKT string

--- a/src/disp_s1/_utils.py
+++ b/src/disp_s1/_utils.py
@@ -162,19 +162,21 @@ def _create_correlation_images(
     return output_paths
 
 
-def extract_footprint(raster_path: PathOrStr, simplify_tolerance: float = 0.05) -> str:
-    """Extract a simplified footprint from a raster file.
+def extract_footprint(raster_path: PathOrStr, simplify_tolerance: float = 0.0) -> str:
+    """Extract the minimum rotated rectangle footprint of a raster file.
 
-    This function opens a raster file, extracts its footprint, simplifies it,
-    and returns the a Polygon from the exterior ring as a WKT string.
+    This function opens a raster file, extracts its convex-hull footprint, takes
+    the minimum rotated rectangle, and returns it as a WKT string.
 
     Parameters
     ----------
     raster_path : str
         Path to the input raster file.
     simplify_tolerance : float, optional
-        Tolerance for simplification of the footprint geometry.
-        Default is 0.05.
+        Tolerance for simplification of the convex hull before taking the
+        minimum rotated rectangle. Default is 0.0 (no simplification): the
+        rectangle is defined by the hull's extreme points, and simplifying pulls
+        them inward, shrinking the box below the data.
 
     Returns
     -------
@@ -185,7 +187,8 @@ def extract_footprint(raster_path: PathOrStr, simplify_tolerance: float = 0.05) 
     Notes
     -----
     This function uses GDAL to open the raster and extract the footprint,
-    and Shapely to process the geometry.
+    and Shapely to process the geometry. 
+
 
     """
     from os import fspath
@@ -203,8 +206,11 @@ def extract_footprint(raster_path: PathOrStr, simplify_tolerance: float = 0.05) 
         simplify=simplify_tolerance,
     )
 
+    # Get rectangular footprint 
+    footprint_geom = shapely.from_wkt(wkt).minimum_rotated_rectangle
+
     # Split on antimeridian and return the WKT string
-    return split_on_antimeridian(shapely.from_wkt(wkt)).wkt
+    return split_on_antimeridian(footprint_geom).wkt
 
 
 def split_on_antimeridian(geometry: Polygon | MultiPolygon) -> MultiPolygon:

--- a/src/disp_s1/main.py
+++ b/src/disp_s1/main.py
@@ -454,11 +454,14 @@ def _assert_no_large_temporal_gaps(
         apart.
 
     """
-    if not isinstance(date_to_files, Mapping):
-        date_to_files = group_by_date(date_to_files, date_idx=0)
+    grouped = (
+        date_to_files
+        if isinstance(date_to_files, Mapping)
+        else group_by_date(date_to_files, date_idx=0)
+    )
     real_dates = sorted(
         date_tuple[0]
-        for date_tuple, files in date_to_files.items()
+        for date_tuple, files in grouped.items()
         if not all("compressed" in str(f).lower() for f in files)
     )
     for earlier, later in zip(real_dates, real_dates[1:]):

--- a/src/disp_s1/main.py
+++ b/src/disp_s1/main.py
@@ -27,6 +27,7 @@ from disp_s1._masking import create_layover_shadow_masks, create_mask_from_dista
 from disp_s1._ps import precompute_ps
 from disp_s1.pge_runconfig import AlgorithmParameters, RunConfig, StaticLayersRunConfig
 
+from ._log import InputValidationError
 from ._reference import ReferencePoint, read_reference_point
 from ._utils import (
     _convert_meters_to_radians,
@@ -36,6 +37,8 @@ from ._utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+__all__ = ["InputValidationError"]
 
 
 @dataclass
@@ -74,6 +77,13 @@ def run(
 
     # Get the dates for any of the burst IDs
     date_to_files = group_by_date(cfg.cslc_file_list, date_idx=0)
+
+    # Fail fast on a malformed input stack before the expensive workflow runs.
+    if pge_runconfig.primary_executable.product_type == "DISP_S1_FORWARD":
+        _assert_forward_mode_compressed(cfg.cslc_file_list)
+
+    _assert_no_large_temporal_gaps(date_to_files)
+
     datetimes_present = list(date_to_files.keys())
     # For forward mode, assume that the last processed was the second-to-last date
     *_, (second_to_last_date,), (_last_date,) = datetimes_present
@@ -414,6 +424,88 @@ def _assert_no_duplicate_dates(input_file_list: Sequence[Path]) -> None:
             file_string = "\n".join(file_list)
             msg += file_string
             raise ValueError(msg)
+
+
+def _assert_no_large_temporal_gaps(
+    date_to_files: Mapping[Sequence[datetime], Sequence[Path]] | Sequence[Path],
+    max_gap_days: float = 2 * 365.25,
+) -> None:
+    """Assert no gap larger than ~2 years between consecutive real SLC dates.
+
+    A multi-year gap in the input stack destroys interferometric coherence and
+    almost always indicates a malformed input list, so we fail fast. Compressed
+    SLCs are excluded here; only the real-SLC acquisition dates are checked.
+
+    Parameters
+    ----------
+    date_to_files : Mapping[Sequence[datetime], Sequence[Path]] | Sequence[Path]
+        Either a mapping from date tuple to the files acquired on that date, as
+        produced by ``group_by_date(cfg.cslc_file_list, date_idx=0)``, or a plain
+        file list (``cfg.cslc_file_list``) which is grouped internally. A date
+        whose files are all compressed SLCs is excluded from the gap check.
+    max_gap_days : float
+        Maximum allowed gap between consecutive real SLC dates, in days.
+        Default = 2 * 365.25 (two years).
+
+    Raises
+    ------
+    ValueError
+        If any consecutive pair of real SLC dates is more than ``max_gap_days``
+        apart.
+
+    """
+    if not isinstance(date_to_files, Mapping):
+        date_to_files = group_by_date(date_to_files, date_idx=0)
+    real_dates = sorted(
+        date_tuple[0]
+        for date_tuple, files in date_to_files.items()
+        if not all("compressed" in str(f).lower() for f in files)
+    )
+    for earlier, later in zip(real_dates, real_dates[1:]):
+        gap_days = (later - earlier).total_seconds() / 86400
+        if gap_days > max_gap_days:
+            msg = (
+                f"Temporal gap of {gap_days / 365.25:.2f} years between"
+                f" {earlier:%Y-%m-%d} and {later:%Y-%m-%d} exceeds the"
+                f" {max_gap_days / 365.25:.0f}-year limit for input SLCs."
+            )
+            raise InputValidationError(msg, error_code=1000)
+
+
+def _assert_forward_mode_compressed(
+    input_file_list: Sequence[Path],
+) -> None:
+    """Assert forward-mode inputs include a compressed SLC connected to the stack.
+
+    Forward mode is incremental, so it must be passed at least one compressed SLC
+    (CCSLC) summarizing the prior ministack. Each compressed SLC must also be
+    connected to the stack: its reference date must overlap the date coverage of
+    one of the input CSLCs — a real SLC's acquisition date, or another compressed
+    SLC's ``[start_date, end_date]`` group. A reference date that overlaps nothing
+    means the CCSLC belongs to a different reference epoch than the stack.
+
+    A compressed SLC is named ``compressed_<ref>_<start>_<end>``, so
+    ``get_dates`` returns ``(reference_date, start_date, end_date)``.
+
+    Parameters
+    ----------
+    input_file_list : Sequence[Path]
+        The input CSLC file list (``cfg.cslc_file_list``).
+
+    Raises
+    ------
+    ValueError
+        If no compressed SLC is present, or a compressed SLC's reference date
+        does not overlap any input CSLC.
+
+    """
+    compressed = [f for f in input_file_list if "compressed" in str(f).lower()]
+    if not compressed:
+        raise InputValidationError(
+            "Forward mode requires at least one compressed SLC (CCSLC) in the"
+            " input CSLC list, but none was found.",
+            error_code=2000,
+        )
 
 
 def _get_near_far_incidence_angles(geometry_files: list[Path]) -> tuple[float, float]:

--- a/src/disp_s1/pge_runconfig.py
+++ b/src/disp_s1/pge_runconfig.py
@@ -32,6 +32,7 @@ from opera_utils import (
 )
 from pydantic import ConfigDict, Field, field_validator
 
+from ._log import InputValidationError
 from .enums import ProcessingMode
 
 
@@ -387,7 +388,8 @@ class RunConfig(YamlModel):
 
         if self.primary_executable.product_type == "DISP_S1_FORWARD":
             param_dict["interferogram_network"] = _create_forward_mode_network(
-                algo_params.forward_mode_network_size
+                algo_params.forward_mode_network_size,
+                cslc_file_list=cslc_file_list,
             )
 
         # unpacked to load the rest of the parameters for the DisplacementWorkflow
@@ -592,7 +594,10 @@ def _parse_algorithm_overrides(
     return {}
 
 
-def _create_forward_mode_network(nearest_n: int = 3) -> InterferogramNetwork:
+def _create_forward_mode_network(
+    nearest_n: int = 3,
+    cslc_file_list: Iterable[PathOrStr] | None = None,
+) -> InterferogramNetwork:
     """Create a smaller interferogram network using only the last date.
 
     For forward mode where we only wish to produce one new product,
@@ -603,7 +608,28 @@ def _create_forward_mode_network(nearest_n: int = 3) -> InterferogramNetwork:
     create that nearest-3 network, and unwrap it.
     We use dolphin's "manual index" option in the `InterferogramNetwork` to
     select the last 4 dates.
+
+    When ``cslc_file_list`` is given, assert the stack is deep enough: the
+    manual indexes reach back ``nearest_n + 1`` positions from the last date,
+    so the ministack must contain at least that many SLCs.
     """
+    # The deepest index used is ``-(nearest_n + 1)`` (e.g. -4 for nearest-3),
+    # so the phase-linked stack needs at least ``nearest_n + 1`` SLCs.
+    min_slc = nearest_n + 1
+    if cslc_file_list is not None:
+        # Use a single burst as the template for the stack depth (all bursts
+        # share the same set of acquisition dates).
+        burst_to_file_list = group_by_burst(cslc_file_list)
+        burst_id = next(iter(burst_to_file_list))
+        num_slc = len(sort_files_by_date(burst_to_file_list[burst_id])[0])
+        if num_slc < min_slc:
+            raise InputValidationError(
+                f"Forward mode nearest-{nearest_n} network requires at least"
+                f" {min_slc} CSLCs in the input stack (including compressed CSLCs),"
+                f" but only {num_slc} were found.",
+                error_code=2002,
+            )
+
     indexes = [
         (-2, -1),
         (-3, -1),
@@ -613,7 +639,7 @@ def _create_forward_mode_network(nearest_n: int = 3) -> InterferogramNetwork:
         (-4, -3),
     ]
     if nearest_n == 4:
-        indexes.extend([(-5, -1), (-5, -2), (-5, -3), (-5, -2)])
+        indexes.extend([(-5, -1), (-5, -2), (-5, -3), (-5, -4)])
     return InterferogramNetwork(indexes=indexes)
 
 

--- a/src/disp_s1/solid_earth_tides.py
+++ b/src/disp_s1/solid_earth_tides.py
@@ -26,9 +26,15 @@ def resample_to_target(
     if array.shape == target_shape:
         return array
     zoom_factors = (target_shape[0] / array.shape[0], target_shape[1] / array.shape[1])
-    out = zoom(array, zoom_factors, order=1)  # Linear interpolation
+    # scipy.ndimage.zoom's C backend rejects float16 ("data type not supported");
+    # the LOS rasters are stored as float16, so upcast before interpolating.
+    data = np.asarray(array)
+    if data.dtype == np.float16:
+        data = data.astype(np.float32)
+    out = zoom(data, zoom_factors, order=1)  # Linear interpolation
     if isinstance(array, np.ma.MaskedArray):
-        mask_out = zoom(array.mask, zoom_factors, order=1).astype(bool)
+        # zoom also rejects bool masks; interpolate as float32 then re-threshold.
+        mask_out = zoom(array.mask.astype(np.float32), zoom_factors, order=1) > 0.5
         out = np.ma.MaskedArray(data=out, mask=mask_out)
     return out
 

--- a/tests/test_pge_runconfig.py
+++ b/tests/test_pge_runconfig.py
@@ -9,6 +9,10 @@ import pytest
 from dolphin.stack import CompressedSlcPlan
 
 from disp_s1 import pge_runconfig
+from disp_s1.main import (
+    _assert_forward_mode_compressed,
+    _assert_no_large_temporal_gaps,
+)
 from disp_s1.pge_runconfig import (
     AlgorithmParameters,
     DynamicAncillaryFileGroup,
@@ -490,3 +494,124 @@ def test_input_file_group_last_processed():
         cslc_file_list=["test_file.h5"], frame_id=12345, last_processed=last_proc_date
     )
     assert file_group_with_date.last_processed == last_proc_date
+
+
+def _make_cslc_names(n, burst="T042-088905-IW1"):
+    """Build ``n`` synthetic, burst-parseable CSLC filenames (one burst, distinct dates)."""
+    return [Path(f"{burst}_202201{i + 1:02d}_20240624.h5") for i in range(n)]
+
+
+class TestCreateForwardModeNetwork:
+    """Tests for `_create_forward_mode_network` and its stack-depth guard."""
+
+    def test_nearest_3_indexes(self):
+        net = pge_runconfig._create_forward_mode_network(3)
+        assert net.indexes == [
+            (-2, -1),
+            (-3, -1),
+            (-4, -1),
+            (-3, -2),
+            (-4, -2),
+            (-4, -3),
+        ]
+
+    def test_nearest_4_indexes(self):
+        # nearest-4 extends the nearest-3 network off the last date with the -5 date;
+        # the final pair must be (-5, -4), not a duplicate of (-5, -2).
+        net = pge_runconfig._create_forward_mode_network(4)
+        assert net.indexes == [
+            (-2, -1),
+            (-3, -1),
+            (-4, -1),
+            (-3, -2),
+            (-4, -2),
+            (-4, -3),
+            (-5, -1),
+            (-5, -2),
+            (-5, -3),
+            (-5, -4),
+        ]
+        # No duplicated pairs snuck in
+        assert len(net.indexes) == len(set(net.indexes))
+
+    def test_no_file_list_skips_guard(self):
+        # Without a file list there is nothing to count, so no assertion runs.
+        net = pge_runconfig._create_forward_mode_network(3, cslc_file_list=None)
+        assert len(net.indexes) == 6
+
+    @pytest.mark.parametrize("nearest_n", [3, 4])
+    def test_enough_slcs_passes(self, nearest_n):
+        # A stack with exactly nearest_n + 1 SLCs is the minimum that works.
+        files = _make_cslc_names(nearest_n + 1)
+        net = pge_runconfig._create_forward_mode_network(
+            nearest_n, cslc_file_list=files
+        )
+        assert net.indexes  # built successfully
+
+    @pytest.mark.parametrize("nearest_n", [3, 4])
+    def test_too_few_slcs_raises(self, nearest_n):
+        # One short of the minimum -> InputValidationError with code 2002.
+        files = _make_cslc_names(nearest_n)  # nearest_n < nearest_n + 1
+        with pytest.raises(pge_runconfig.InputValidationError) as exc_info:
+            pge_runconfig._create_forward_mode_network(
+                nearest_n, cslc_file_list=files
+            )
+        assert exc_info.value.error_code == 2002
+
+    def test_counts_across_multiple_bursts(self):
+        # Depth is measured from a single burst; extra bursts don't inflate the count.
+        files = _make_cslc_names(3, burst="T042-088905-IW1") + _make_cslc_names(
+            3, burst="T042-088906-IW2"
+        )
+        with pytest.raises(pge_runconfig.InputValidationError) as exc_info:
+            pge_runconfig._create_forward_mode_network(3, cslc_file_list=files)
+        assert exc_info.value.error_code == 2002
+
+
+class TestAssertNoLargeTemporalGaps:
+    """Tests for `_assert_no_large_temporal_gaps` (error 1000)."""
+
+    def test_contiguous_stack_passes(self):
+        files = [Path("s_20200101.h5"), Path("s_20200601.h5"), Path("s_20210101.h5")]
+        # No return value; simply must not raise.
+        assert _assert_no_large_temporal_gaps(files) is None
+
+    def test_large_gap_raises(self):
+        files = [Path("s_20160101.h5"), Path("s_20190301.h5")]  # ~3.1 year gap
+        with pytest.raises(pge_runconfig.InputValidationError) as exc_info:
+            _assert_no_large_temporal_gaps(files)
+        assert exc_info.value.error_code == 1000
+
+    def test_compressed_dates_excluded_from_gap(self):
+        # A compressed SLC sitting inside the gap must not "fill" it: only real-SLC
+        # dates are scanned, so the >2-year gap between the reals still raises.
+        files = [
+            Path("s_20160101.h5"),
+            Path("compressed_20170101_20160101_20170101.tif"),
+            Path("s_20190301.h5"),
+        ]
+        with pytest.raises(pge_runconfig.InputValidationError) as exc_info:
+            _assert_no_large_temporal_gaps(files)
+        assert exc_info.value.error_code == 1000
+
+    def test_gap_just_under_limit_passes(self):
+        # ~1.9 years apart -> under the 2-year limit.
+        files = [Path("s_20200101.h5"), Path("s_20211101.h5")]
+        assert _assert_no_large_temporal_gaps(files) is None
+
+
+class TestAssertForwardModeCompressed:
+    """Tests for `_assert_forward_mode_compressed` (error 2000)."""
+
+    def test_no_compressed_raises(self):
+        files = [Path("s_20200101.h5"), Path("s_20200113.h5")]
+        with pytest.raises(pge_runconfig.InputValidationError) as exc_info:
+            _assert_forward_mode_compressed(files)
+        assert exc_info.value.error_code == 2000
+
+    def test_with_compressed_passes(self):
+        files = [
+            Path("compressed_20170430_20170217_20170430.tif"),
+            Path("s_20200101.h5"),
+        ]
+        assert _assert_forward_mode_compressed(files) is None

--- a/tests/test_pge_runconfig.py
+++ b/tests/test_pge_runconfig.py
@@ -497,7 +497,7 @@ def test_input_file_group_last_processed():
 
 
 def _make_cslc_names(n, burst="T042-088905-IW1"):
-    """Build ``n`` synthetic, burst-parseable CSLC filenames (one burst, distinct dates)."""
+    """Build ``n`` synthetic, burst-parseable CSLC filenames (distinct dates)."""
     return [Path(f"{burst}_202201{i + 1:02d}_20240624.h5") for i in range(n)]
 
 
@@ -553,9 +553,7 @@ class TestCreateForwardModeNetwork:
         # One short of the minimum -> InputValidationError with code 2002.
         files = _make_cslc_names(nearest_n)  # nearest_n < nearest_n + 1
         with pytest.raises(pge_runconfig.InputValidationError) as exc_info:
-            pge_runconfig._create_forward_mode_network(
-                nearest_n, cslc_file_list=files
-            )
+            pge_runconfig._create_forward_mode_network(nearest_n, cslc_file_list=files)
         assert exc_info.value.error_code == 2002
 
     def test_counts_across_multiple_bursts(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 
+import h5py
 import numpy as np
 import pytest
+import shapely
 from dolphin import io
 from dolphin.workflows import UnwrapOptions
 from shapely import MultiPolygon, from_wkt
@@ -12,6 +14,7 @@ from disp_s1._utils import (
     _create_correlation_images,
     _update_snaphu_conncomps,
     _update_spurt_conncomps,
+    extract_footprint,
     split_on_antimeridian,
 )
 
@@ -177,6 +180,101 @@ def test_update_spurt_conncomps(setup_test_files):
         ts_stem = ts_p.stem  # e.g. "20160708_20170603"
         assert cc_p.stem.startswith(ts_stem)
         assert cc_p.name.endswith(".unw.conncomp.tif"), f"Wrong extension for {cc_p}"
+
+
+def test_extract_footprint_gdal_canary(tmp_path):
+    """GDAL-version canary for ``extract_footprint``.
+
+    Writes a synthetic raster with a *diagonal* band of valid pixels (an
+    axis-aligned block would hide orientation/rotation bugs) and asserts the
+    footprint is a single rotated-rectangle MULTIPOLYGON that contains every
+    valid cell. If a future GDAL changes ``gdal.Footprint`` -- re-introducing
+    simplification, flipping orientation, or altering the convex hull so the box
+    no longer covers the data -- this test will flag it.
+    """
+    n = 30
+    arr = np.zeros((n, n), dtype="uint8")
+    rr, cc = np.mgrid[0:n, 0:n]
+    arr[np.abs(rr - cc) < 4] = 1  # diagonal stripe
+
+    # Simple north-up EPSG:4326 georeferencing (1 px = 0.01 deg).
+    gt = (-120.0, 0.01, 0.0, 40.0, 0.0, -0.01)
+    tif = tmp_path / "synthetic.tif"
+    io.write_arr(
+        arr=arr,
+        output_name=tif,
+        geotransform=gt,
+        projection="EPSG:4326",
+        dtype="uint8",
+        nodata=0,
+    )
+
+    geom = from_wkt(extract_footprint(tif))
+    assert geom.geom_type == "MultiPolygon"
+    assert len(geom.geoms[0].exterior.coords) == 5  # rotated rectangle
+
+    vy, vx = np.where(arr)
+    lon = gt[0] + (vx + 0.5) * gt[1]
+    lat = gt[3] + (vy + 0.5) * gt[5]
+    assert shapely.contains(geom, shapely.points(lon, lat)).all()
+
+
+def test_recompute_matches_forward_footprint(tmp_path):
+    """The recompute script reproduces the forward bounding polygon.
+
+    Wraps one synthetic array into a GeoTIFF (the forward ``unw`` input that
+    ``product.py`` footprints) and a CF NetCDF (the product the recompute script
+    reads back), then asserts the two bounding polygons are identical. This locks
+    in forward/recompute parity and fails if a future GDAL's NetCDF y-flip ever
+    leaks through the h5py read path. No external data needed.
+    """
+    import sys
+
+    from pyproj import CRS
+
+    sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+    from recompute_product_bounds import compute_bounding_polygon
+
+    # Small diagonal valid band (value 1, else 0) -> non-trivial rotated rect.
+    n = 30
+    arr = np.zeros((n, n), dtype="float32")
+    rr, cc = np.mgrid[0:n, 0:n]
+    arr[np.abs(rr - cc) < 4] = 1.0
+
+    gt = (302070.0, 10.0, 0.0, 4058360.0, 0.0, -10.0)
+    crs = CRS.from_epsg(32638)
+
+    # Forward "unw" GeoTIFF (footprinted directly by product.py).
+    geotiff = tmp_path / "unw.tif"
+    io.write_arr(
+        arr=arr,
+        output_name=geotiff,
+        geotransform=gt,
+        projection=crs.to_wkt(),
+        dtype="float32",
+        nodata=0,
+    )
+
+    # Product NetCDF wrapping the same data in CF (y, x) layout.
+    x = gt[0] + (np.arange(n) + 0.5) * gt[1]
+    y = gt[3] + (np.arange(n) + 0.5) * gt[5]
+    nc = tmp_path / "product.nc"
+    with h5py.File(nc, "w") as f:
+        f.attrs["Conventions"] = "CF-1.8"
+        xds = f.create_dataset("x", data=x)
+        xds.make_scale()
+        yds = f.create_dataset("y", data=y)
+        yds.make_scale()
+        dds = f.create_dataset("displacement", data=arr)
+        dds.dims[0].attach_scale(yds)
+        dds.dims[1].attach_scale(xds)
+        dds.attrs["grid_mapping"] = "spatial_ref"
+        sr = f.create_dataset("spatial_ref", data=0)
+        sr.attrs["crs_wkt"] = crs.to_wkt()
+
+    forward = from_wkt(extract_footprint(geotiff))
+    recompute = from_wkt(compute_bounding_polygon(nc))
+    assert forward.equals(recompute)
 
 
 def test_check_split_on_antimeridian():


### PR DESCRIPTION
## Summary

Two independent fixes for the DISP-S1 forward-mode workflow.

### 1. Product bounding-box fix (#376)
- `_utils.py`: `extract_footprint` now returns the minimum rotated rectangle of
  the convex hull (default `simplify_tolerance=0.0`).
- New `scripts/recompute_product_bounds.py` recomputes/corrects product bounds.
- `scripts/recompute_bperp_bbounds.py` updates the **product bounds** and the **perpendicular baseline** together in one pass.
- Tests: `scripts/test_recompute_product_bounds.py`, `scripts/test_recompute_bperp_bbounds.py`.

```bash
cd scripts
python recompute_bperp_bbounds.py \
    --input-file /path/to/OPERA_L3_DISP-S1_..._v1.0.nc \
    --output-file /path/to/OPERA_L3_DISP-S1_..._corrected.nc
```

### 2. Input prechecks (fail fast with typed error codes)
| Check | Error code |
|---|---|
| Large temporal gap between real-SLC dates (> 2 yr) | **1000** |
| Forward mode requires ≥ 1 compressed SLC (CCSLC) | **2000** |
| Forward-mode inputs too small for the inversion network (< `nearest_n + 1` SLCs) | **2002** |

Each check has a corresponding unit test in `tests/test_pge_runconfig.py` (`TestAssertNoLargeTemporalGaps`, `TestAssertForwardModeCompressed`, `TestCreateForwardModeNetwork`).

## Other updates:
### Forward-mode network (`src/disp_s1/pge_runconfig.py`)

- `_create_forward_mode_network` now accepts `cslc_file_list` and asserts the
  single-burst stack has at least `nearest_n + 1` SLCs before building the
  manual network; too-shallow stacks raise `InputValidationError` (error code
  2002). The count is taken from one burst (all bursts share dates) and includes
  compressed SLCs.
- Fixed the `nearest_n == 4` network: the final pair is now `(-5, -4)` instead
  of a duplicated `(-5, -2)`.

### Solid-earth-tides float16 fix (`src/disp_s1/solid_earth_tides.py`)

- `resample_to_target` upcasts float16 → float32 before
  `scipy.ndimage.zoom`; the current scipy rejects float16 with
  `RuntimeError: data type not supported`. Masks are interpolated as float32 and
  re-thresholded.

### Tooling / misc

- `docker-compose.yml`: local build/run of the disp-s1 image (overlays
  `./src/disp_s1` for live edits, mounts configs/data and `~/.aws`/`~/.netrc`).
- `conda-env.yml`, `tests/test_utils.py` updates.
